### PR TITLE
refactor attempt with extension service

### DIFF
--- a/x-pack/platform/packages/shared/index-management/index_management_shared_types/src/services/extensions_service.ts
+++ b/x-pack/platform/packages/shared/index-management/index_management_shared_types/src/services/extensions_service.ts
@@ -23,7 +23,7 @@ export type IndexMappingContent =
       renderText?: () => ReactElement;
       renderLink?: () => ReactElement;
     }
-  | undefined;
+  | false;
 export interface IndexToggle {
   matchIndex: (index: Index) => boolean;
   label: string;

--- a/x-pack/platform/packages/shared/index-management/index_management_shared_types/src/services/extensions_service.ts
+++ b/x-pack/platform/packages/shared/index-management/index_management_shared_types/src/services/extensions_service.ts
@@ -5,7 +5,7 @@
  * 2.0.
  */
 
-import type { FunctionComponent, ReactNode } from 'react';
+import type { FunctionComponent, ReactElement, ReactNode } from 'react';
 import type { ApplicationStart } from '@kbn/core-application-browser';
 import type { EuiBadgeProps } from '@elastic/eui';
 import type { IndexDetailsTab } from '../home_sections';
@@ -18,6 +18,12 @@ export interface IndexContent {
   }) => ReturnType<FunctionComponent>;
 }
 
+export type IndexMappingContent =
+  | {
+      renderText?: () => ReactElement;
+      renderLink?: () => ReactElement;
+    }
+  | undefined;
 export interface IndexToggle {
   matchIndex: (index: Index) => boolean;
   label: string;
@@ -69,8 +75,10 @@ export interface ExtensionsSetup {
   addIndexDetailsTab(tab: IndexDetailsTab): void;
   // sets content to render instead of the code block on the overview tab of the index page
   setIndexOverviewContent(content: IndexContent): void;
-  // sets content to render below the docs link on the mappings tab of the index page
-  setIndexMappingsContent(content: IndexContent): void;
+  // sets content to render on the right side of the mappings tab of the index page
+  setIndexMappingsContentAbout(content: IndexMappingContent): void;
+  // sets the extra content below the docs link on the mappings tab of the index page
+  setIndexMappingsContentExtra(content: IndexMappingContent): void;
   // sets index details page route
   setIndexDetailsPageRoute(route: IndexDetailsPageRoute, detailsTabId?: string): void;
 }

--- a/x-pack/platform/plugins/shared/content_connectors/public/app.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/app.tsx
@@ -25,6 +25,10 @@ import { useKibanaContextForPluginProvider } from './utils/use_kibana';
 import { AppContextProvider } from './app_context';
 import { PLUGIN_ID } from '../common/constants';
 import { mountFlashMessagesLogic } from './components/shared/flash_messages';
+import {
+  createConnectorMappingAboutContent,
+  createConnectorMappingExtraContent,
+} from './components/search_index/index_mappings';
 
 export const renderApp = (
   core: CoreStart,
@@ -103,6 +107,12 @@ const AppWithExecutionContext = ({
   const indexMappingComponent = plugins.indexManagement?.getIndexMappingComponent({
     history: params.history,
   });
+  plugins.indexManagement?.extensionsService.setIndexMappingsContentExtra(
+    createConnectorMappingExtraContent()
+  );
+  plugins.indexManagement?.extensionsService.setIndexMappingsContentAbout(
+    createConnectorMappingAboutContent()
+  );
 
   const appContext = {
     connectorTypes,

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/index_mappings.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/index_mappings.tsx
@@ -9,18 +9,7 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import {
-  EuiCallOut,
-  EuiCode,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiLink,
-  EuiPanel,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiCallOut, EuiCode, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
@@ -38,6 +27,53 @@ import { AccessControlIndexSelector } from './access_control_index_selector/acce
 import { mappingsWithPropsApiLogic } from '../../api/mappings/mappings_logic';
 import { stripSearchPrefix } from '../../utils/strip_search_prefix';
 import { useAppContext } from '../../app_context';
+
+export const createConnectorMappingAboutContent = () => {
+  return {
+    renderLink: () => (
+      <EuiLink
+        data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnHowToCustomizeIndexMappingsAndSettingsLink"
+        href={docLinks.connectorsMappings}
+        target="_blank"
+        external
+      >
+        <FormattedMessage
+          id="xpack.contentConnectors.content.searchIndex.mappings.docLink"
+          defaultMessage="Learn how to customize index mappings and settings"
+        />
+      </EuiLink>
+    ),
+    renderText: () => (
+      <FormattedMessage
+        id="xpack.contentConnectors.content.searchIndex.mappings.description"
+        defaultMessage="Your documents are made up of a set of fields. Index mappings give each field a type 
+          (such as {keyword}, {number}, or {date}) and additional subfields. By default, search optimized mappings are used which can be customized as needed to best fit your search use case."
+        values={{
+          date: <EuiCode>date</EuiCode>,
+          keyword: <EuiCode>keyword</EuiCode>,
+          number: <EuiCode>number</EuiCode>,
+        }}
+      />
+    ),
+  };
+};
+
+export const createConnectorMappingExtraContent = () => {
+  return {
+    renderLink: () => (
+      <EuiLink
+        data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnMoreLink"
+        href={docLinks.ingestPipelines}
+        target="_blank"
+        external
+      >
+        {i18n.translate('xpack.contentConnectors.content.searchIndex.transform.docLink', {
+          defaultMessage: 'Learn more',
+        })}
+      </EuiLink>
+    ),
+  };
+};
 
 export const SearchIndexIndexMappings: React.FC = () => {
   const {
@@ -103,6 +139,7 @@ export const SearchIndexIndexMappings: React.FC = () => {
                 </EuiCallOut>
               ) : (
                 <>
+                  stack content connectors
                   {IndexMappingComponent ? (
                     <IndexMappingComponent
                       index={{
@@ -127,87 +164,6 @@ export const SearchIndexIndexMappings: React.FC = () => {
               )}
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiFlexItem>
-        <EuiFlexItem grow={1}>
-          <EuiPanel grow={false} hasShadow={false} hasBorder>
-            <EuiFlexGroup justifyContent="center" gutterSize="s" alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiIcon type="info" />
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiTitle size="xs">
-                  <h3>
-                    {i18n.translate('xpack.contentConnectors.content.searchIndex.mappings.title', {
-                      defaultMessage: 'About index mappings',
-                    })}
-                  </h3>
-                </EuiTitle>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer size="s" />
-            <EuiText size="s">
-              <p>
-                <FormattedMessage
-                  id="xpack.contentConnectors.content.searchIndex.mappings.description"
-                  defaultMessage="Your documents are made up of a set of fields. Index mappings give each field a type (such as {keyword}, {number}, or {date}) and additional subfields. By default, search optimized mappings are used which can be customized as needed to best fit your search use case."
-                  values={{
-                    date: <EuiCode>date</EuiCode>,
-                    keyword: <EuiCode>keyword</EuiCode>,
-                    number: <EuiCode>number</EuiCode>,
-                  }}
-                />
-              </p>
-            </EuiText>
-            <EuiSpacer size="s" />
-            <EuiLink
-              data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnHowToCustomizeIndexMappingsAndSettingsLink"
-              href={docLinks.connectorsMappings}
-              target="_blank"
-              external
-            >
-              {i18n.translate('xpack.contentConnectors.content.searchIndex.mappings.docLink', {
-                defaultMessage: 'Learn how to customize index mappings and settings',
-              })}
-            </EuiLink>
-          </EuiPanel>
-          <EuiSpacer />
-          <EuiPanel grow={false} hasShadow={false} hasBorder>
-            <EuiFlexGroup justifyContent="center" gutterSize="s" alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiIcon type="info" />
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiTitle size="xs">
-                  <h3>
-                    {i18n.translate('xpack.contentConnectors.content.searchIndex.transform.title', {
-                      defaultMessage: 'Transform your searchable content',
-                    })}
-                  </h3>
-                </EuiTitle>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-
-            <EuiSpacer size="s" />
-            <EuiText size="s">
-              <p>
-                <FormattedMessage
-                  id="xpack.contentConnectors.content.searchIndex.transform.description"
-                  defaultMessage="Want to add custom fields, or use trained ML models to analyze and enrich your indexed documents? Use index-specific ingest pipelines to customize documents to your needs."
-                />
-              </p>
-            </EuiText>
-            <EuiSpacer size="s" />
-            <EuiLink
-              data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnMoreLink"
-              href={docLinks.ingestPipelines}
-              target="_blank"
-              external
-            >
-              {i18n.translate('xpack.contentConnectors.content.searchIndex.transform.docLink', {
-                defaultMessage: 'Learn more',
-              })}
-            </EuiLink>
-          </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/index_mappings.tsx
+++ b/x-pack/platform/plugins/shared/content_connectors/public/components/search_index/index_mappings.tsx
@@ -139,7 +139,6 @@ export const SearchIndexIndexMappings: React.FC = () => {
                 </EuiCallOut>
               ) : (
                 <>
-                  stack content connectors
                   {IndexMappingComponent ? (
                     <IndexMappingComponent
                       index={{

--- a/x-pack/platform/plugins/shared/index_management/README.md
+++ b/x-pack/platform/plugins/shared/index_management/README.md
@@ -1,12 +1,17 @@
 # Index Management UI
+
 ## Extensions service
-This service is exposed from the Index Management setup contract and can be used to add content to the indices list and the index details page. 
+
+This service is exposed from the Index Management setup contract and can be used to add content to the indices list and the index details page.
+
 ### Extensions to the indices list
+
 - `addBanner(banner: any)`: adds a banner on top of the indices list, for example when some indices run into an ILM issue
-- `addFilter(filter: any)`: adds a filter to the indices list, for example to filter indices managed by ILM 
+- `addFilter(filter: any)`: adds a filter to the indices list, for example to filter indices managed by ILM
 - `addToggle(toggle: any)`: adds a toggle to the indices list, for example to display hidden indices
 - `addColumn(column: IndicesListColumn)`: adds a column to the indices list, for example to display an ILM phase
 - `setEmptyListContent(content: EmptyListContent)`: replaces the default empty prompt displayed when there are no indices in the indices list. The empty list content has the following interface:
+
 ```ts
 export interface EmptyListContent {
   renderContent: (args: {
@@ -14,14 +19,16 @@ export interface EmptyListContent {
   }) => ReturnType<FunctionComponent>;
 }
 ```
+
 - `setIndexDetailsPageRoute`: registers a new route for index details page in indices list table. For example, for serverless search users, navigating to an index on the indices list page will lead to the Search Indices detail page.
 
-
 #### Extensions to the indices list and the index details page
+
 - `addAction(action: any)`: adds an option to the "manage index" menu, for example to add an ILM policy to the index
 - `addBadge(badge: any)`: adds a badge to the index name, for example to indicate frozen, rollup or follower indices
 
 #### Extensions to the index details page
+
 - `addIndexDetailsTab(tab: IndexDetailsTab)`: adds a tab to the index details page. The tab has the following interface:
 
 ```ts
@@ -45,7 +52,8 @@ interface IndexDetailsTab {
 
 An example of adding an ILM tab can be found in [this file](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/private/index_lifecycle_management/public/extend_index_management/components/index_lifecycle_summary.tsx#L250).
 
-- `setIndexOverviewContent(content: IndexContent)`: replaces the default content in the overview tab (code block describing adding documents to the index) with the custom content. The custom content has the following interface: 
+- `setIndexOverviewContent(content: IndexContent)`: replaces the default content in the overview tab (code block describing adding documents to the index) with the custom content. The custom content has the following interface:
+
 ```ts
 interface IndexContent {
   renderContent: (args: {
@@ -53,14 +61,17 @@ interface IndexContent {
     getUrlForApp: ApplicationStart['getUrlForApp'];
   }) => ReturnType<FunctionComponent>;
 ```
-- `setIndexMappingsContent(content: IndexContent)`: adds content to the mappings tab of the index details page. The content is displayed in the right bottom corner, below the mappings docs link. 
+
+- `setIndexMappingsContentAbout(content: IndexMappingContent)`: sets the mappings description text and link to the proper documentation.
+- `setIndexMappingsContentExtra(content: IndexMappingContent)`: adds more content to the mappings tab of the index details page. The content is displayed in the right bottom corner, below the mappings docs link.
 
 ## Index data enrichers
+
 The extensions service that allows to render additional UI elements in the indices list and on the index details page often
-relies on additional index data that is not available by default. To make these additional data available in the response of 
+relies on additional index data that is not available by default. To make these additional data available in the response of
 the `GET /indices` request, an index data enricher can be registered. A data enricher is essentially an extra request that is
-done for the array of indices and the information is added to the response. Currently, 3 data enrichers are registered 
-by the ILM, Rollup and CCR plugins. Before adding a data enricher, the cost of the additional request should be taken 
+done for the array of indices and the information is added to the response. Currently, 3 data enrichers are registered
+by the ILM, Rollup and CCR plugins. Before adding a data enricher, the cost of the additional request should be taken
 in consideration (see [this file](https://github.com/elastic/kibana/blob/main/x-pack/platform/plugins/shared/index_management/server/services/index_data_enricher.ts) for more details).
 
 ## Indices tab

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -25,6 +25,7 @@ import {
   useGeneratedHtmlId,
   useEuiBreakpoint,
   EuiToolTip,
+  EuiCode,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { i18n } from '@kbn/i18n';
@@ -70,9 +71,13 @@ import { EmptyMappingsContent } from './details_page_empty_mappings';
 
 const isInferencePreconfigured = (inferenceId: string) => inferenceId.startsWith('.');
 
-const MappingsAboutContent = (props: IndexMappingContent) => {
+interface MappingsContentProps {
+  content: IndexMappingContent | null;
+}
+
+const MappingsAboutContent = ({ content }: MappingsContentProps) => {
   return (
-    <EuiPanel grow={false} paddingSize="l" color="subdued">
+    <EuiPanel grow={false} paddingSize="l" hasShadow={false} hasBorder>
       <EuiFlexGroup alignItems="center" gutterSize="s">
         <EuiFlexItem grow={false}>
           <EuiIcon type="info" />
@@ -89,23 +94,28 @@ const MappingsAboutContent = (props: IndexMappingContent) => {
         </EuiFlexItem>
       </EuiFlexGroup>
       <EuiSpacer size="s" />
-      {props?.renderText ? (
-        props.renderText()
-      ) : (
-        <EuiText>
-          <p>
+      <EuiText>
+        <p>
+          {content && content.renderText ? (
+            content.renderText()
+          ) : (
             <FormattedMessage
-              id="xpack.idxMgmt.indexDetails.mappings.docsCardDescription"
-              defaultMessage="Your documents are made up of a set of fields. Index mappings give each field a type
-                      (such as keyword, number, or date) and additional subfields. These index mappings determine the functions
-                      available in your relevance tuning and search experience."
+              id="xpack.enterpriseSearch.content.searchIndex.mappings.description"
+              defaultMessage="Your documents are made up of a set of fields. Index mappings give each field a type 
+                (such as {keyword}, {number}, or {date}) and additional subfields. These index mappings determine the functions
+                available in your relevance tuning and search experience."
+              values={{
+                date: <EuiCode>date</EuiCode>,
+                keyword: <EuiCode>keyword</EuiCode>,
+                number: <EuiCode>number</EuiCode>,
+              }}
             />
-          </p>
-        </EuiText>
-      )}
+          )}
+        </p>
+      </EuiText>
       <EuiSpacer size="m" />
-      {props?.renderLink ? (
-        props.renderLink()
+      {content && content.renderLink ? (
+        content.renderLink()
       ) : (
         <EuiLink
           data-test-subj="indexDetailsMappingsDocsLink"
@@ -123,49 +133,53 @@ const MappingsAboutContent = (props: IndexMappingContent) => {
   );
 };
 
-const MappingsExtraContent = (props: IndexMappingContent) => (
-  <EuiPanel grow={false} hasShadow={false} hasBorder>
-    <EuiFlexGroup justifyContent="center" gutterSize="s" alignItems="center">
+const MappingsExtraContent = ({ content }: MappingsContentProps) => (
+  <EuiPanel grow={false} paddingSize="l" hasShadow={false} hasBorder>
+    <EuiFlexGroup gutterSize="s" alignItems="center">
       <EuiFlexItem grow={false}>
         <EuiIcon type="info" />
       </EuiFlexItem>
       <EuiFlexItem>
         <EuiTitle size="xs">
           <h3>
-            {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.title', {
-              defaultMessage: 'Transform your searchable content',
-            })}
+            <FormattedMessage
+              id="xpack.idxMgmt.indexDetails.mappings.transform.title"
+              defaultMessage="Transform your searchable content"
+            />
           </h3>
         </EuiTitle>
       </EuiFlexItem>
     </EuiFlexGroup>
 
     <EuiSpacer size="s" />
-    {props?.renderText ? (
-      props.renderText()
-    ) : (
-      <EuiText size="s">
-        <p>
+    <EuiText>
+      <p>
+        {content && content.renderText ? (
+          content.renderText()
+        ) : (
           <FormattedMessage
-            id="xpack.enterpriseSearch.content.searchIndex.transform.description"
-            defaultMessage="Want to add custom fields, or use trained ML models to analyze and enrich your indexed documents? Use index-specific ingest pipelines to customize documents to your needs."
+            id="xpack.idxMgmt.indexDetails.mappings.transform.description"
+            defaultMessage="Want to add custom fields, or use trained ML models 
+            to analyze and enrich your indexed documents? Use index-specific ingest pipelines 
+            to customize documents to your needs."
           />
-        </p>
-      </EuiText>
-    )}
+        )}
+      </p>
+    </EuiText>
     <EuiSpacer size="s" />
-    {props?.renderLink ? (
-      props.renderLink()
+    {content && content.renderLink ? (
+      content.renderLink()
     ) : (
       <EuiLink
-        data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnMoreLink"
+        data-test-subj="indexDetailsMappingsLearnMoreLink"
         href={documentationService.docLinks.enterpriseSearch.ingestPipelines}
         target="_blank"
         external
       >
-        {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.docLink', {
-          defaultMessage: 'Learn more',
-        })}
+        <FormattedMessage
+          id="xpack.idxMgmt.indexDetails.mappings.transform.docLink"
+          defaultMessage="Learn more"
+        />
       </EuiLink>
     )}
   </EuiPanel>
@@ -182,7 +196,6 @@ export const DetailsPageMappingsContent: FunctionComponent<{
   const {
     services: { extensionsService },
     core: {
-      getUrlForApp,
       application: { capabilities, navigateToUrl },
       http,
     },
@@ -192,9 +205,8 @@ export const DetailsPageMappingsContent: FunctionComponent<{
     history,
   } = useAppContext();
   const pendingFieldsRef = useRef<HTMLDivElement>(null);
-  const showAboutContent = extensionsService.indexMappingsContentAbout !== undefined;
-  const showExtraContent = extensionsService.indexMappingsContentExtra !== undefined;
-
+  const showAboutContent = extensionsService.indexMappingsContentAbout !== false;
+  const showExtraContent = extensionsService.indexMappingsContentExtra !== false;
   const [isPlatinumLicense, setIsPlatinumLicense] = useState<boolean>(false);
   useEffect(() => {
     const subscription = licensing?.license$.subscribe((license: ILicense) => {
@@ -576,73 +588,31 @@ export const DetailsPageMappingsContent: FunctionComponent<{
     // using "rowReverse" to keep docs links on the top of the mappings code block on smaller screen
     <>
       <EuiFlexGroup wrap direction="rowReverse" css={mappingsWrapperStyles}>
-        {hasMappings && showAboutContent && (
+        {hasMappings && (
           <EuiFlexItem grow={false} css={showAboutMappingsStyles}>
-            <MappingsAboutContent
-              renderText={extensionsService.indexMappingsContentAbout?.renderText}
-              renderLink={extensionsService.indexMappingsContentAbout?.renderLink}
-            />
-          </EuiFlexItem>
-        )}
-        {hasMappings && showExtraContent && (
-          <EuiFlexItem grow={false} css={showAboutMappingsStyles}>
-            <MappingsExtraContent
-              renderText={extensionsService.indexMappingsContentExtra?.renderText}
-              renderLink={extensionsService.indexMappingsContentExtra?.renderLink}
-            />
-          </EuiFlexItem>
-        )}
-        {/* {showAboutMappings && (
-          <EuiFlexItem grow={false} css={showAboutMappingsStyles}>
-            <EuiPanel grow={false} paddingSize="l" color="subdued">
-              <EuiFlexGroup alignItems="center" gutterSize="s">
+            <EuiFlexGroup direction="column">
+              {showAboutContent && (
                 <EuiFlexItem grow={false}>
-                  <EuiIcon type="info" />
+                  <MappingsAboutContent content={extensionsService.indexMappingsContentAbout} />
                 </EuiFlexItem>
-                <EuiFlexItem>
-                  <EuiTitle size="xs">
-                    <h2>
-                      <FormattedMessage
-                        id="xpack.idxMgmt.indexDetails.mappings.docsCardTitle"
-                        defaultMessage="About index mappings"
-                      />
-                    </h2>
-                  </EuiTitle>
+              )}
+              {showExtraContent && (
+                <EuiFlexItem grow={false}>
+                  <MappingsExtraContent content={extensionsService.indexMappingsContentExtra} />
                 </EuiFlexItem>
-              </EuiFlexGroup>
-              <EuiSpacer size="s" />
-              <EuiText>
-                <p>
-                  <FormattedMessage
-                    id="xpack.idxMgmt.indexDetails.mappings.docsCardDescription"
-                    defaultMessage="Your documents are made up of a set of fields. Index mappings give each field a type
-                      (such as keyword, number, or date) and additional subfields. These index mappings determine the functions
-                      available in your relevance tuning and search experience."
-                  />
-                </p>
-              </EuiText>
-              <EuiSpacer size="m" />
-              <EuiLink
-                data-test-subj="indexDetailsMappingsDocsLink"
-                href={documentationService.getMappingDocumentationLink()}
-                target="_blank"
-                external
-              >
-                <FormattedMessage
-                  id="xpack.idxMgmt.indexDetails.mappings.docsCardLink"
-                  defaultMessage="Learn more about mappings"
-                />
-              </EuiLink>
-            </EuiPanel>
-            {extensionsService.indexMappingsContent && (
-              <>
-                <EuiSpacer />
-                {extensionsService.indexMappingsContent.renderContent({ index, getUrlForApp })}
-              </>
-            )}
+              )}
+            </EuiFlexGroup>
           </EuiFlexItem>
-        )} */}
+        )}
         <EuiFlexGroup direction="column" gutterSize="s">
+          {hasMLPermissions && !hasSemanticText && (
+            <EuiFlexItem grow={true}>
+              <SemanticTextBanner
+                isSemanticTextEnabled={isSemanticTextEnabled}
+                isPlatinumLicense={isPlatinumLicense}
+              />
+            </EuiFlexItem>
+          )}
           {!hasMappings &&
             (!isAddingFields ? (
               <EmptyMappingsContent addFieldButton={AddFieldButton} />
@@ -704,14 +674,6 @@ export const DetailsPageMappingsContent: FunctionComponent<{
                 </EuiFilterGroup>
               </EuiFlexItem>
             </EuiFlexGroup>
-          )}
-          {hasMLPermissions && !hasSemanticText && (
-            <EuiFlexItem grow={true}>
-              <SemanticTextBanner
-                isSemanticTextEnabled={isSemanticTextEnabled}
-                isPlatinumLicense={isPlatinumLicense}
-              />
-            </EuiFlexItem>
           )}
           {errorSavingMappings}
           {isAddingFields && (

--- a/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
+++ b/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx
@@ -33,6 +33,7 @@ import type { FunctionComponent } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ILicense } from '@kbn/licensing-types';
 import { useUnsavedChangesPrompt } from '@kbn/unsaved-changes-prompt';
+import type { IndexMappingContent } from '@kbn/index-management-shared-types';
 import {
   getStateWithCopyToFields,
   isSemanticTextField,
@@ -69,6 +70,107 @@ import { EmptyMappingsContent } from './details_page_empty_mappings';
 
 const isInferencePreconfigured = (inferenceId: string) => inferenceId.startsWith('.');
 
+const MappingsAboutContent = (props: IndexMappingContent) => {
+  return (
+    <EuiPanel grow={false} paddingSize="l" color="subdued">
+      <EuiFlexGroup alignItems="center" gutterSize="s">
+        <EuiFlexItem grow={false}>
+          <EuiIcon type="info" />
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiTitle size="xs">
+            <h2>
+              <FormattedMessage
+                id="xpack.idxMgmt.indexDetails.mappings.docsCardTitle"
+                defaultMessage="About index mappings"
+              />
+            </h2>
+          </EuiTitle>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+      <EuiSpacer size="s" />
+      {props?.renderText ? (
+        props.renderText()
+      ) : (
+        <EuiText>
+          <p>
+            <FormattedMessage
+              id="xpack.idxMgmt.indexDetails.mappings.docsCardDescription"
+              defaultMessage="Your documents are made up of a set of fields. Index mappings give each field a type
+                      (such as keyword, number, or date) and additional subfields. These index mappings determine the functions
+                      available in your relevance tuning and search experience."
+            />
+          </p>
+        </EuiText>
+      )}
+      <EuiSpacer size="m" />
+      {props?.renderLink ? (
+        props.renderLink()
+      ) : (
+        <EuiLink
+          data-test-subj="indexDetailsMappingsDocsLink"
+          href={documentationService.getMappingDocumentationLink()}
+          target="_blank"
+          external
+        >
+          <FormattedMessage
+            id="xpack.idxMgmt.indexDetails.mappings.docsCardLink"
+            defaultMessage="Learn more about mappings"
+          />
+        </EuiLink>
+      )}
+    </EuiPanel>
+  );
+};
+
+const MappingsExtraContent = (props: IndexMappingContent) => (
+  <EuiPanel grow={false} hasShadow={false} hasBorder>
+    <EuiFlexGroup justifyContent="center" gutterSize="s" alignItems="center">
+      <EuiFlexItem grow={false}>
+        <EuiIcon type="info" />
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiTitle size="xs">
+          <h3>
+            {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.title', {
+              defaultMessage: 'Transform your searchable content',
+            })}
+          </h3>
+        </EuiTitle>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+
+    <EuiSpacer size="s" />
+    {props?.renderText ? (
+      props.renderText()
+    ) : (
+      <EuiText size="s">
+        <p>
+          <FormattedMessage
+            id="xpack.enterpriseSearch.content.searchIndex.transform.description"
+            defaultMessage="Want to add custom fields, or use trained ML models to analyze and enrich your indexed documents? Use index-specific ingest pipelines to customize documents to your needs."
+          />
+        </p>
+      </EuiText>
+    )}
+    <EuiSpacer size="s" />
+    {props?.renderLink ? (
+      props.renderLink()
+    ) : (
+      <EuiLink
+        data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnMoreLink"
+        href={documentationService.docLinks.enterpriseSearch.ingestPipelines}
+        target="_blank"
+        external
+      >
+        {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.docLink', {
+          defaultMessage: 'Learn more',
+        })}
+      </EuiLink>
+    )}
+  </EuiPanel>
+);
+
 export const DetailsPageMappingsContent: FunctionComponent<{
   index: Index;
   data: string;
@@ -90,6 +192,8 @@ export const DetailsPageMappingsContent: FunctionComponent<{
     history,
   } = useAppContext();
   const pendingFieldsRef = useRef<HTMLDivElement>(null);
+  const showAboutContent = extensionsService.indexMappingsContentAbout !== undefined;
+  const showExtraContent = extensionsService.indexMappingsContentExtra !== undefined;
 
   const [isPlatinumLicense, setIsPlatinumLicense] = useState<boolean>(false);
   useEffect(() => {
@@ -472,7 +576,23 @@ export const DetailsPageMappingsContent: FunctionComponent<{
     // using "rowReverse" to keep docs links on the top of the mappings code block on smaller screen
     <>
       <EuiFlexGroup wrap direction="rowReverse" css={mappingsWrapperStyles}>
-        {showAboutMappings && (
+        {hasMappings && showAboutContent && (
+          <EuiFlexItem grow={false} css={showAboutMappingsStyles}>
+            <MappingsAboutContent
+              renderText={extensionsService.indexMappingsContentAbout?.renderText}
+              renderLink={extensionsService.indexMappingsContentAbout?.renderLink}
+            />
+          </EuiFlexItem>
+        )}
+        {hasMappings && showExtraContent && (
+          <EuiFlexItem grow={false} css={showAboutMappingsStyles}>
+            <MappingsExtraContent
+              renderText={extensionsService.indexMappingsContentExtra?.renderText}
+              renderLink={extensionsService.indexMappingsContentExtra?.renderLink}
+            />
+          </EuiFlexItem>
+        )}
+        {/* {showAboutMappings && (
           <EuiFlexItem grow={false} css={showAboutMappingsStyles}>
             <EuiPanel grow={false} paddingSize="l" color="subdued">
               <EuiFlexGroup alignItems="center" gutterSize="s">
@@ -521,7 +641,7 @@ export const DetailsPageMappingsContent: FunctionComponent<{
               </>
             )}
           </EuiFlexItem>
-        )}
+        )} */}
         <EuiFlexGroup direction="column" gutterSize="s">
           {!hasMappings &&
             (!isAddingFields ? (

--- a/x-pack/platform/plugins/shared/index_management/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/plugin.ts
@@ -239,8 +239,13 @@ export class IndexMgmtUIPlugin
     this.licensingSubscription = licensing?.license$.subscribe((next) => {
       this.canUseSyntheticSource = next.hasAtLeast('enterprise');
     });
+    const extensionsApi = this.extensionsService.setup();
+    // extensionsApi.setIndexMappingsContent({
+    //   renderContent: () => 'HI bro',
+    // });
+
     return {
-      extensionsService: this.extensionsService.setup(),
+      extensionsService: extensionsApi,
       getIndexMappingComponent: (deps: { history: ScopedHistory<unknown> }) => {
         return (props: IndexMappingProps) => {
           return IndexMapping({

--- a/x-pack/platform/plugins/shared/index_management/public/plugin.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/plugin.ts
@@ -239,13 +239,9 @@ export class IndexMgmtUIPlugin
     this.licensingSubscription = licensing?.license$.subscribe((next) => {
       this.canUseSyntheticSource = next.hasAtLeast('enterprise');
     });
-    const extensionsApi = this.extensionsService.setup();
-    // extensionsApi.setIndexMappingsContent({
-    //   renderContent: () => 'HI bro',
-    // });
 
     return {
-      extensionsService: extensionsApi,
+      extensionsService: this.extensionsService.setup(),
       getIndexMappingComponent: (deps: { history: ScopedHistory<unknown> }) => {
         return (props: IndexMappingProps) => {
           return IndexMapping({

--- a/x-pack/platform/plugins/shared/index_management/public/services/extensions_service.ts
+++ b/x-pack/platform/plugins/shared/index_management/public/services/extensions_service.ts
@@ -14,6 +14,7 @@ import type {
   IndexContent,
   ExtensionsSetup,
   IndexDetailsPageRoute,
+  IndexMappingContent,
 } from '@kbn/index-management-shared-types';
 import type { IndexDetailsTab } from '../../common/constants';
 
@@ -48,7 +49,8 @@ export class ExtensionsService {
   private _emptyListContent: EmptyListContent | null = null;
   private _indexDetailsTabs: IndexDetailsTab[] = [];
   private _indexOverviewContent: IndexContent | null = null;
-  private _indexMappingsContent: IndexContent | null = null;
+  private _indexMappingsContentAbout: IndexMappingContent | null = null;
+  private _indexMappingsContentExtra: IndexMappingContent | null = null;
   private _indexDetailsPageRoute: IndexDetailsPageRoute | null = null;
   private service?: ExtensionsSetup;
 
@@ -63,7 +65,8 @@ export class ExtensionsService {
       setEmptyListContent: this.setEmptyListContent.bind(this),
       addIndexDetailsTab: this.addIndexDetailsTab.bind(this),
       setIndexOverviewContent: this.setIndexOverviewContent.bind(this),
-      setIndexMappingsContent: this.setIndexMappingsContent.bind(this),
+      setIndexMappingsContentAbout: this.setIndexMappingsContentAbout.bind(this),
+      setIndexMappingsContentExtra: this.setIndexMappingsContentExtra.bind(this),
       setIndexDetailsPageRoute: this.setIndexDetailsPageRoute.bind(this),
     };
 
@@ -114,13 +117,22 @@ export class ExtensionsService {
     }
   }
 
-  private setIndexMappingsContent(content: IndexContent) {
-    if (this._indexMappingsContent) {
-      throw new Error(`The content for index mappings has already been set.`);
+  private setIndexMappingsContentAbout(content: IndexMappingContent) {
+    if (this._indexMappingsContentAbout) {
+      throw new Error(`The about content for index mappings has already been set.`);
     } else {
-      this._indexMappingsContent = content;
+      this._indexMappingsContentAbout = content;
     }
   }
+
+  private setIndexMappingsContentExtra(content: IndexMappingContent) {
+    if (this._indexMappingsContentExtra) {
+      throw new Error(`The extra content for index mappings has already been set.`);
+    } else {
+      this._indexMappingsContentExtra = content;
+    }
+  }
+
   private setIndexDetailsPageRoute(route: IndexDetailsPageRoute) {
     if (this._indexDetailsPageRoute) {
       throw new Error(`The route for index details has already been set.`);
@@ -165,8 +177,11 @@ export class ExtensionsService {
     return this._indexOverviewContent;
   }
 
-  public get indexMappingsContent() {
-    return this._indexMappingsContent;
+  public get indexMappingsContentAbout() {
+    return this._indexMappingsContentAbout;
+  }
+  public get indexMappingsContentExtra() {
+    return this._indexMappingsContentExtra;
   }
   public get indexDetailsPageRoute() {
     return this._indexDetailsPageRoute;

--- a/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
+++ b/x-pack/solutions/search/plugins/enterprise_search/public/applications/enterprise_search_content/components/search_index/index_mappings.tsx
@@ -9,24 +9,16 @@ import React, { useEffect, useMemo, useState } from 'react';
 
 import { useActions, useValues } from 'kea';
 
-import {
-  EuiCallOut,
-  EuiCode,
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiLink,
-  EuiPanel,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiCallOut, EuiCode, EuiFlexGroup, EuiFlexItem, EuiLink } from '@elastic/eui';
 
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+
 import { CONNECTORS_ACCESS_CONTROL_INDEX_PREFIX } from '../../../../../common/constants';
 import { stripSearchPrefix } from '../../../../../common/utils/strip_search_prefix';
+import type { PluginsStart } from '../../../../plugin';
 
 import { docLinks } from '../../../shared/doc_links';
 
@@ -41,9 +33,61 @@ import { IndexViewLogic } from './index_view_logic';
 
 import './index_mappings.scss';
 
+export const createConnectorMappingAboutContent = () => {
+  return {
+    renderLink: () => (
+      <EuiLink
+        data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnHowToCustomizeIndexMappingsAndSettingsLink"
+        href={docLinks.connectorsMappings}
+        target="_blank"
+        external
+      >
+        {i18n.translate('xpack.enterpriseSearch.content.searchIndex.mappings.docLink', {
+          defaultMessage: 'Learn how to customize index mappings and settings',
+        })}
+      </EuiLink>
+    ),
+    renderText: () => (
+      <FormattedMessage
+        id="xpack.enterpriseSearch.content.searchIndex.mappings.description"
+        defaultMessage="Your documents are made up of a set of fields. Index mappings give each field a type (such as {keyword}, {number}, or {date}) and additional subfields. By default, search optimized mappings are used which can be customized as needed to best fit your search use case."
+        values={{
+          date: <EuiCode>date</EuiCode>,
+          keyword: <EuiCode>keyword</EuiCode>,
+          number: <EuiCode>number</EuiCode>,
+        }}
+      />
+    ),
+  };
+};
+
+export const createConnectorMappingExtraContent = () => {
+  return {
+    renderLink: () => (
+      <EuiLink
+        data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnMoreLink"
+        href={docLinks.ingestPipelines}
+        target="_blank"
+        external
+      >
+        {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.docLink', {
+          defaultMessage: 'Learn more',
+        })}
+      </EuiLink>
+    ),
+  };
+};
+
 export const SearchIndexIndexMappings: React.FC = () => {
   const { indexName } = useValues(IndexNameLogic);
   const { hasDocumentLevelSecurityFeature, isHiddenIndex } = useValues(IndexViewLogic);
+  const { services } = useKibana<PluginsStart>();
+  services.indexManagement?.extensionsService.setIndexMappingsContentAbout(
+    createConnectorMappingAboutContent()
+  );
+  services.indexManagement?.extensionsService.setIndexMappingsContentExtra(
+    createConnectorMappingExtraContent()
+  );
   const { indexMappingComponent, productFeatures } = useValues(KibanaLogic);
 
   const IndexMappingComponent = useMemo(() => indexMappingComponent, []);
@@ -122,87 +166,6 @@ export const SearchIndexIndexMappings: React.FC = () => {
               )}
             </EuiFlexItem>
           </EuiFlexGroup>
-        </EuiFlexItem>
-        <EuiFlexItem grow={1}>
-          <EuiPanel grow={false} hasShadow={false} hasBorder>
-            <EuiFlexGroup justifyContent="center" gutterSize="s" alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiIcon type="info" />
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiTitle size="xs">
-                  <h3>
-                    {i18n.translate('xpack.enterpriseSearch.content.searchIndex.mappings.title', {
-                      defaultMessage: 'About index mappings',
-                    })}
-                  </h3>
-                </EuiTitle>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-            <EuiSpacer size="s" />
-            <EuiText size="s">
-              <p>
-                <FormattedMessage
-                  id="xpack.enterpriseSearch.content.searchIndex.mappings.description"
-                  defaultMessage="Your documents are made up of a set of fields. Index mappings give each field a type (such as {keyword}, {number}, or {date}) and additional subfields. By default, search optimized mappings are used which can be customized as needed to best fit your search use case."
-                  values={{
-                    date: <EuiCode>date</EuiCode>,
-                    keyword: <EuiCode>keyword</EuiCode>,
-                    number: <EuiCode>number</EuiCode>,
-                  }}
-                />
-              </p>
-            </EuiText>
-            <EuiSpacer size="s" />
-            <EuiLink
-              data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnHowToCustomizeIndexMappingsAndSettingsLink"
-              href={docLinks.connectorsMappings}
-              target="_blank"
-              external
-            >
-              {i18n.translate('xpack.enterpriseSearch.content.searchIndex.mappings.docLink', {
-                defaultMessage: 'Learn how to customize index mappings and settings',
-              })}
-            </EuiLink>
-          </EuiPanel>
-          <EuiSpacer />
-          <EuiPanel grow={false} hasShadow={false} hasBorder>
-            <EuiFlexGroup justifyContent="center" gutterSize="s" alignItems="center">
-              <EuiFlexItem grow={false}>
-                <EuiIcon type="info" />
-              </EuiFlexItem>
-              <EuiFlexItem>
-                <EuiTitle size="xs">
-                  <h3>
-                    {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.title', {
-                      defaultMessage: 'Transform your searchable content',
-                    })}
-                  </h3>
-                </EuiTitle>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-
-            <EuiSpacer size="s" />
-            <EuiText size="s">
-              <p>
-                <FormattedMessage
-                  id="xpack.enterpriseSearch.content.searchIndex.transform.description"
-                  defaultMessage="Want to add custom fields, or use trained ML models to analyze and enrich your indexed documents? Use index-specific ingest pipelines to customize documents to your needs."
-                />
-              </p>
-            </EuiText>
-            <EuiSpacer size="s" />
-            <EuiLink
-              data-test-subj="enterpriseSearchSearchIndexIndexMappingsLearnMoreLink"
-              href={docLinks.ingestPipelines}
-              target="_blank"
-              external
-            >
-              {i18n.translate('xpack.enterpriseSearch.content.searchIndex.transform.docLink', {
-                defaultMessage: 'Learn more',
-              })}
-            </EuiLink>
-          </EuiPanel>
         </EuiFlexItem>
       </EuiFlexGroup>
     </>

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_mappings_docs_link.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_mappings_docs_link.tsx
@@ -26,7 +26,6 @@ export const createIndexMappingsContentExtra = (core: CoreStart) => {
         target="_blank"
         external
       >
-        svls search version
         <FormattedMessage
           id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.linkLabel"
           defaultMessage="Learn more about ingest pipelines"

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_mappings_docs_link.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_mappings_docs_link.tsx
@@ -19,7 +19,6 @@ import {
 } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { CoreStart } from '@kbn/core/public';
-import type { IndexContent } from '@kbn/index-management-shared-types';
 
 const IndexMappingsDocsLink: FunctionComponent<{ docLinks: CoreStart['docLinks'] }> = ({
   docLinks,
@@ -67,8 +66,31 @@ const IndexMappingsDocsLink: FunctionComponent<{ docLinks: CoreStart['docLinks']
   );
 };
 
-export const createIndexMappingsDocsLinkContent = (core: CoreStart): IndexContent => {
+export const createIndexMappingsContentExtra = (core: CoreStart) => {
   return {
-    renderContent: () => <IndexMappingsDocsLink docLinks={core.docLinks} />,
+    renderText: () => (
+      <EuiText>
+        <p>
+          <FormattedMessage
+            id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.description"
+            defaultMessage="Want to add custom fields, or use trained ML models to analyze and enrich your
+          indexed documents? Use index-specific ingest pipelines to customize documents to your needs."
+          />
+        </p>
+      </EuiText>
+    ),
+    renderLink: () => (
+      <EuiLink
+        data-test-subj="serverlessSearchIndexMappingsDocsLinkLearnMoreAboutIngestPipelinesLink"
+        href={core.docLinks.links.enterpriseSearch.ingestPipelines}
+        target="_blank"
+        external
+      >
+        <FormattedMessage
+          id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.linkLabel"
+          defaultMessage="Learn more about ingest pipelines"
+        />
+      </EuiLink>
+    ),
   };
 };

--- a/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_mappings_docs_link.tsx
+++ b/x-pack/solutions/search/plugins/serverless_search/public/application/components/index_management/index_mappings_docs_link.tsx
@@ -5,79 +5,19 @@
  * 2.0.
  */
 
-import type { FunctionComponent } from 'react';
 import React from 'react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiIcon,
-  EuiLink,
-  EuiPanel,
-  EuiSpacer,
-  EuiText,
-  EuiTitle,
-} from '@elastic/eui';
+import { EuiLink } from '@elastic/eui';
 import { FormattedMessage } from '@kbn/i18n-react';
 import type { CoreStart } from '@kbn/core/public';
-
-const IndexMappingsDocsLink: FunctionComponent<{ docLinks: CoreStart['docLinks'] }> = ({
-  docLinks,
-}) => {
-  return (
-    <EuiPanel grow={false} paddingSize="l">
-      <EuiFlexGroup alignItems="center" gutterSize="s">
-        <EuiFlexItem grow={false}>
-          <EuiIcon type="info" />
-        </EuiFlexItem>
-        <EuiFlexItem>
-          <EuiTitle size="xs">
-            <h2>
-              <FormattedMessage
-                id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.title"
-                defaultMessage="Transform your searchable content"
-              />
-            </h2>
-          </EuiTitle>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-      <EuiSpacer size="s" />
-      <EuiText>
-        <p>
-          <FormattedMessage
-            id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.description"
-            defaultMessage="Want to add custom fields, or use trained ML models to analyze and enrich your
-          indexed documents? Use index-specific ingest pipelines to customize documents to your needs."
-          />
-        </p>
-      </EuiText>
-      <EuiSpacer size="m" />
-      <EuiLink
-        data-test-subj="serverlessSearchIndexMappingsDocsLinkLearnMoreAboutIngestPipelinesLink"
-        href={docLinks.links.enterpriseSearch.ingestPipelines}
-        target="_blank"
-        external
-      >
-        <FormattedMessage
-          id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.linkLabel"
-          defaultMessage="Learn more about ingest pipelines"
-        />
-      </EuiLink>
-    </EuiPanel>
-  );
-};
 
 export const createIndexMappingsContentExtra = (core: CoreStart) => {
   return {
     renderText: () => (
-      <EuiText>
-        <p>
-          <FormattedMessage
-            id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.description"
-            defaultMessage="Want to add custom fields, or use trained ML models to analyze and enrich your
+      <FormattedMessage
+        id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.description"
+        defaultMessage="Want to add custom fields, or use trained ML models to analyze and enrich your
           indexed documents? Use index-specific ingest pipelines to customize documents to your needs."
-          />
-        </p>
-      </EuiText>
+      />
     ),
     renderLink: () => (
       <EuiLink
@@ -86,6 +26,7 @@ export const createIndexMappingsContentExtra = (core: CoreStart) => {
         target="_blank"
         external
       >
+        svls search version
         <FormattedMessage
           id="xpack.serverlessSearch.indexMappings.ingestPipelinesDocs.linkLabel"
           defaultMessage="Learn more about ingest pipelines"

--- a/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
@@ -192,10 +192,6 @@ export class ServerlessSearchPlugin
     indexManagement?.extensionsService.setIndexMappingsContentExtra(
       createIndexMappingsContentExtra(core)
     );
-    // indexManagement?.extensionsService.setIndexMappingsContentAbout(
-    //   // createIndexMappingsContentExtra(core)
-    //   null
-    // );
     indexManagement?.extensionsService.setIndexOverviewContent(
       createIndexOverviewContent(core, services)
     );

--- a/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
+++ b/x-pack/solutions/search/plugins/serverless_search/public/plugin.ts
@@ -12,7 +12,7 @@ import { appCategories, appIds } from '@kbn/management-cards-navigation';
 import type { AuthenticatedUser } from '@kbn/security-plugin/common';
 import { QueryClient, MutationCache, QueryCache } from '@tanstack/react-query';
 import { of } from 'rxjs';
-import { createIndexMappingsDocsLinkContent as createIndexMappingsContent } from './application/components/index_management/index_mappings_docs_link';
+import { createIndexMappingsContentExtra } from './application/components/index_management/index_mappings_docs_link';
 import { createIndexOverviewContent } from './application/components/index_management/index_overview_content';
 import { docLinks } from '../common/doc_links';
 import type {
@@ -189,8 +189,13 @@ export class ServerlessSearchPlugin
       hideLinksTo: [appIds.MAINTENANCE_WINDOWS],
       extendCardNavDefinitions,
     });
-
-    indexManagement?.extensionsService.setIndexMappingsContent(createIndexMappingsContent(core));
+    indexManagement?.extensionsService.setIndexMappingsContentExtra(
+      createIndexMappingsContentExtra(core)
+    );
+    // indexManagement?.extensionsService.setIndexMappingsContentAbout(
+    //   // createIndexMappingsContentExtra(core)
+    //   null
+    // );
     indexManagement?.extensionsService.setIndexOverviewContent(
       createIndexOverviewContent(core, services)
     );


### PR DESCRIPTION
As part of adding index mapping empty state: [PR](https://github.com/elastic/kibana/pull/231899)

We want to conditionally hide the extra about/help text when there are no mappings. 
To do this, we have to have the rendering of this content happen in the place that we know about whether or not mappings exist (only here: https://github.com/elastic/kibana/blob/db0b92448b751e3f8accee34f4e1cfe19309701d/x-pack/platform/plugins/shared/index_management/public/application/sections/home/index_list/details_page/details_page_mappings_content.tsx#L188)

That text is rendered in several places:
* Stack Mgmt Index Mgmt (source of the IndexMappingComponent) - default "About" content
* Stack Mgmt Connectors 
	* sets `showAboutMappings` as false on `IndexMappingComponent`
	* Recreates the "About" and "Transform" panels within its own plugin code
* Search Content Connectors
	* same as Stack Mgmt connectors with slightly different links and text
* Serverless Search Index Mgmt
	* uses `indexManagement?.extensionsService` to populate the "Transform" section
	
This Draft PR is an attempt to consolidate some duplicated code. I tried adding to the Index Managment plugin's extension service. adding a method to set `About` and `Extra` content. Then all the users of the plugin could populate those items with just the unique text or link they want to use for `About` and `Extra`.

This doesn't work because extension service cannot call the same method twice. When two plugins are loaded that depend on Index Management plugin, they both try to set that content and one fails.

## Solutions:
* Don't conditionally show/hide the about/transform sections
* Consolidate all of the extra text and links to be just one version, and put it in the Index Management plugin.
* Add some props to the IndexManagement plugin and drill custom content for those sections through the props.