### PR TITLE
Dual-mode Kibana launcher scripts and skills

### DIFF
--- a/.agents/skills/kbn-dev-status/SKILL.md
+++ b/.agents/skills/kbn-dev-status/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: kbn-dev-status
 description: >
-  Show the current status of the local Kibana dev environment.
-  Use when the user types /kbn-dev-status or asks "is kibana running",
-  "kibana status", "what's the state of kbn".
-disable-model-invocation: true
+  Quick status check for the local Kibana dev environment. Use when the
+  user asks "is kibana running", "kibana status", "what's the state of
+  kibana", "check kibana", "kbn status", "what's kibana doing", or types
+  /kbn-dev-status. This is the lightweight skill — for start/stop/restart
+  actions, use /kbn-dev instead.
 allowed-tools: >
   Bash(source * && yarn kbn-dev-ctl *)
   Bash(yarn kbn-dev-ctl *)
@@ -12,14 +13,13 @@ allowed-tools: >
 
 # Kibana Status
 
-Source nvm first, then run `yarn kbn-dev-ctl status --json` and present a
-concise summary. Do NOT show raw JSON.
+Source nvm, then present status. Do NOT show raw JSON.
 
 ```
 !`source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use 2>/dev/null && nvm use --silent 2>/dev/null; yarn kbn-dev-ctl status --json 2>/dev/null || echo '{"running": false}'`
 ```
 
-Format the output as:
+Format as:
 
 | Component | Status | Ready |
 |-----------|--------|-------|
@@ -29,7 +29,7 @@ Format the output as:
 | Kibana SLS | up/down | yes/no |
 | Kibana Stack | up/down | yes/no |
 
-Add URLs for ready Kibana instances:
+Add URLs for ready instances:
 - Serverless: http://localhost:5601
 - Stateful: http://localhost:5611
 

--- a/.agents/skills/kbn-dev-status/SKILL.md
+++ b/.agents/skills/kbn-dev-status/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: kbn-dev-status
+description: >
+  Show the current status of the local Kibana dev environment.
+  Use when the user types /kbn-dev-status or asks "is kibana running",
+  "kibana status", "what's the state of kbn".
+disable-model-invocation: true
+allowed-tools: Bash(yarn kbn-dev-ctl *)
+---
+
+# Kibana Status
+
+Run `yarn kbn-dev-ctl status --json` from the kibana repo root and present a
+concise summary. Do NOT show raw JSON.
+
+```
+!`yarn kbn-dev-ctl status --json 2>/dev/null || echo '{"running": false}'`
+```
+
+Format the output as:
+
+| Component | Status | Ready |
+|-----------|--------|-------|
+| ES Serverless | up/down | yes/no |
+| ES Stateful | up/down | yes/no |
+| Optimizer | up/down | — |
+| Kibana SLS | up/down | yes/no |
+| Kibana Stack | up/down | yes/no |
+
+Add URLs for ready Kibana instances:
+- Serverless: http://localhost:5601
+- Stateful: http://localhost:5611
+
+If not running, say "Kibana is not running. Start with /kbn-dev"

--- a/.agents/skills/kbn-dev-status/SKILL.md
+++ b/.agents/skills/kbn-dev-status/SKILL.md
@@ -5,16 +5,18 @@ description: >
   Use when the user types /kbn-dev-status or asks "is kibana running",
   "kibana status", "what's the state of kbn".
 disable-model-invocation: true
-allowed-tools: Bash(yarn kbn-dev-ctl *)
+allowed-tools: >
+  Bash(source * && yarn kbn-dev-ctl *)
+  Bash(yarn kbn-dev-ctl *)
 ---
 
 # Kibana Status
 
-Run `yarn kbn-dev-ctl status --json` from the kibana repo root and present a
+Source nvm first, then run `yarn kbn-dev-ctl status --json` and present a
 concise summary. Do NOT show raw JSON.
 
 ```
-!`yarn kbn-dev-ctl status --json 2>/dev/null || echo '{"running": false}'`
+!`source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use 2>/dev/null && nvm use --silent 2>/dev/null; yarn kbn-dev-ctl status --json 2>/dev/null || echo '{"running": false}'`
 ```
 
 Format the output as:

--- a/.agents/skills/kbn-dev/SKILL.md
+++ b/.agents/skills/kbn-dev/SKILL.md
@@ -66,7 +66,8 @@ state. The key fields are `"running"` (is the orchestrator PID alive) and
   Report what's up and what's down. Offer to restart the failed component.
 - **`"running": false`**: Start it (steps 1-5 below).
 
-If the user says "restart kibana", use `yarn kbn-dev-ctl stop` then start fresh.
+If the user says "restart kibana", use `yarn kbn-dev-ctl restart all`.
+Restart always does a full stop + start (ES + Kibana together).
 
 **Starting Kibana is a background task.** Don't show the user every poll
 cycle. Follow this pattern:
@@ -125,17 +126,23 @@ one message when ready (or failed).
 | Status (human) | `yarn kbn-dev-ctl status` |
 | Logs | `yarn kbn-dev-ctl logs <component> [--tail N] [--grep PATTERN]` |
 | Attach tmux | `yarn kbn-dev-ctl attach` |
-| Restart Kibana | `yarn kbn-dev-ctl restart <kbnsls\|kbnstack>` |
+| Restart | `yarn kbn-dev-ctl restart <serverless\|stateful\|all>` |
 | Stop | `yarn kbn-dev-ctl stop` |
 
 Components: `essls`, `esstack`, `optimizer`, `kbnsls`, `kbnstack`, `main`, `all`
 
-## When to restart Kibana
+## When to restart
 
-Check `yarn kbn-dev-ctl status --json` and restart if a Kibana component shows
+Check `yarn kbn-dev-ctl status --json` and restart if a component shows
 `"alive": false` — common after branch switches, plugin code changes,
-or config edits. The monitor loop in `kbn-dev` auto-restarts after the kill.
-ES clusters and the optimizer stay running.
+or config edits. Restart always does a full stop + start (ES + Kibana
+together), never just Kibana alone.
+
+```bash
+yarn kbn-dev-ctl restart serverless   # restart ES Serverless + Kibana SLS
+yarn kbn-dev-ctl restart stateful     # restart ES Stateful + Kibana Stack
+yarn kbn-dev-ctl restart all          # restart everything
+```
 
 ## Instance details and authentication
 
@@ -179,7 +186,7 @@ codes, or error messages.
 
 See [failure-modes.md](failure-modes.md) for detailed patterns. Key fixes:
 - **Node mismatch**: `nvm install $(cat .nvmrc)`
-- **Port in use**: `yarn kbn-dev-ctl restart <component>`
+- **Port in use**: `yarn kbn-dev-ctl restart all`
 - **Docker not running**: start Docker
 - **After branch switch**: `yarn kbn-dev --quiet --clean`
 - **Vault failed**: `KBN_INFERENCE_URL="" yarn kbn-dev --quiet`
@@ -219,5 +226,6 @@ use the browser to navigate there and verify visually.
 ## Proactive monitoring
 
 After editing `.ts`, `.tsx`, `.yml`, or config files, silently run
-`yarn kbn-dev-ctl status --json`. If a component is down, restart it and tell
-the user briefly: "Kibana SLS crashed, restarting..."
+`yarn kbn-dev-ctl status --json`. If a component is down, run
+`yarn kbn-dev-ctl restart serverless` (or `stateful`) and tell the user
+briefly: "Kibana SLS crashed, restarting..."

--- a/.agents/skills/kbn-dev/SKILL.md
+++ b/.agents/skills/kbn-dev/SKILL.md
@@ -52,15 +52,19 @@ Check status before taking any action:
 ## UX guidelines — be concise
 
 **Check status first.** The dynamic injection above gives you the current
-state. Handle each case:
+state. The key fields are `"running"` (is the orchestrator PID alive) and
+`"state"` (what phase it's in). Handle each case:
 
-- **Already running, both ready**: Tell the user "Kibana is already running"
-  and show the URLs. Do NOT restart unless the user explicitly asks.
-- **Already running, partially ready**: Report what's up and what's down.
-  Offer to restart the failed component.
-- **Running but not ready yet**: A previous session started kbn-dev and it's
-  still booting. Poll for readiness (step 3 below) instead of restarting.
-- **Not running**: Start it (steps 1-5 below).
+- **`"running": true`, both kbnsls and kbnstack show `"ready": true`**:
+  Tell the user "Kibana is already running" and show the URLs. Do NOT
+  restart unless the user explicitly asks.
+- **`"running": true`, state is `"starting"` / `"es_starting"` / `"optimizer_ready"`**:
+  Kibana is already starting up (from this or a previous session). Tell
+  the user "Kibana is currently starting up (state: X). I'll monitor it."
+  Then poll for readiness (step 3 below). Do NOT start a second instance.
+- **`"running": true`, partially ready (one up, one down)**:
+  Report what's up and what's down. Offer to restart the failed component.
+- **`"running": false`**: Start it (steps 1-5 below).
 
 If the user says "restart kibana", use `yarn kbn-dev-ctl stop` then start fresh.
 

--- a/.agents/skills/kbn-dev/SKILL.md
+++ b/.agents/skills/kbn-dev/SKILL.md
@@ -155,6 +155,28 @@ once at the start of a shell session, then run yarn commands normally.
 
 Components: `essls`, `esstack`, `optimizer`, `kbnsls`, `kbnstack`, `main`, `all`
 
+### Viewing logs
+
+**"Open the logs" / "show me all logs":**
+The tmux log viewer requires an interactive terminal, so you can't attach
+to it directly. Tell the user to run it themselves:
+
+> Run `yarn kbn-dev-ctl attach` in your terminal to open the tmux log
+> viewer with all four panes (ES Serverless, ES Stateful, Kibana SLS,
+> Kibana Stack).
+
+**Showing logs inline (what you CAN do):**
+Use `yarn kbn-dev-ctl logs <component>` to show logs in the agent shell.
+This works for targeted requests like "show me serverless errors":
+
+```bash
+yarn kbn-dev-ctl logs kbnsls --tail 50              # last 50 lines
+yarn kbn-dev-ctl logs all --grep "ERROR|FATAL"       # errors across all
+yarn kbn-dev-ctl logs essls --tail 20 --grep error   # ES serverless errors
+```
+
+Do NOT try to open terminal tabs, run AppleScript, or `tail -f` manually.
+
 ## When to restart
 
 Check `yarn kbn-dev-ctl status --json` and restart if a component shows

--- a/.agents/skills/kbn-dev/SKILL.md
+++ b/.agents/skills/kbn-dev/SKILL.md
@@ -13,6 +13,8 @@ description: >
   "start es and kibana", "spin up kibana", "kibana dev", "restart kibana",
   "check kibana", "kibana logs", "es logs", or "kibana status".
 allowed-tools: >
+  Bash(source * && yarn kbn-dev-ctl *)
+  Bash(source * && yarn kbn-dev *)
   Bash(yarn kbn-dev-ctl *)
   Bash(yarn kbn-dev *)
   Bash(curl *)
@@ -41,12 +43,28 @@ kbn-dev (orchestrator, long-running)
 
 `yarn kbn-dev` is the startup orchestrator. `yarn kbn-dev-ctl` is the control plane.
 
+## IMPORTANT: nvm required before yarn commands
+
+Agent shells don't load nvm, so the system node version won't match kibana's
+`.nvmrc`. Yarn's engine check rejects commands before the script even runs.
+**Always source nvm before any yarn command:**
+
+```bash
+source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use && nvm use --silent && yarn kbn-dev-ctl ...
+```
+
+Shorthand used throughout this skill: `nvm_use` = `source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use && nvm use --silent`
+
+Every `yarn` invocation below MUST be prefixed with this. If you run a
+bare `yarn kbn-dev-ctl` without sourcing nvm first, it will fail with
+"The engine node is incompatible".
+
 ## Current status
 
 Check status before taking any action:
 
 ```
-!`yarn kbn-dev-ctl status --json 2>/dev/null || echo '{"running": false, "state": "not_running"}'`
+!`source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use 2>/dev/null && nvm use --silent 2>/dev/null; yarn kbn-dev-ctl status --json 2>/dev/null || echo '{"running": false, "state": "not_running"}'`
 ```
 
 ## UX guidelines — be concise
@@ -78,6 +96,7 @@ cycle. Follow this pattern:
 2. Run `yarn kbn-dev --quiet` in the background (it checks if already running).
 3. Poll silently with a **simple sleep loop** — do NOT show output:
    ```bash
+   source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use && nvm use --silent
    for i in $(seq 1 40); do
      sleep 15
      kbn_state=$(yarn kbn-dev-ctl status --json 2>/dev/null)
@@ -118,6 +137,9 @@ finishes, tell the user:
 one message when ready (or failed).
 
 ## Commands
+
+All commands must be prefixed with nvm sourcing (see above). Source nvm
+once at the start of a shell session, then run yarn commands normally.
 
 | Action | Command |
 |--------|---------|
@@ -206,15 +228,41 @@ working, or to check/test UI behavior:
 Do NOT search the codebase for UI questions that can be answered by
 looking at or curling the running app.
 
-- **Serverless** (port 5601): navigate to `http://localhost:5601`.
-  If a login/role selection screen appears, select the **admin** role.
-  The dev serverless setup uses mock authentication — no password needed,
-  just pick the role from the selector.
-- **Stateful** (port 5611): navigate to `http://localhost:5611`.
-  If a login screen appears, enter username `elastic` and password
-  `changeme`. Always use these credentials for stateful.
+### Handling login screens
 
-Common Kibana app paths:
+When you navigate to a Kibana instance and see a login/auth screen
+instead of the expected page, handle it automatically:
+
+**Serverless (port 5601) — Role selector:**
+The dev serverless instance uses mock authentication. Instead of a
+username/password form, you'll see a **role selection page** with
+profile cards for different roles (e.g. `admin`, `editor`, `viewer`,
+`t1_analyst`, `t2_analyst`, etc.).
+- Look for a card/button labeled **"admin"** (or containing "admin"
+  in the role name) and click it.
+- Default to `admin` unless the user specifically requests a different
+  role.
+- After selecting a role, you'll be redirected to the Kibana app. If
+  you land on a space selector, pick **Default** space.
+- There is no password. Just select the role.
+
+**Stateful (port 5611) — Login form:**
+The stateful instance uses a standard login form.
+- Find the **username** input field and type: `elastic`
+- Find the **password** input field and type: `changeme`
+- Click the **"Log in"** button.
+- If you see an "Enter code" or enrollment screen instead, the ES
+  cluster may not be configured correctly — report this to the user.
+
+**Detecting auth screens:**
+- If the URL contains `/login` or the page shows "Log in to Elastic"
+  or a role selector grid, you're on an auth page.
+- If you see a 401 or "Unauthorized" response, the session expired —
+  repeat the login flow.
+- After successful auth, navigate to the originally requested URL.
+
+### Common Kibana app paths
+
 - Getting started / onboarding: `/app/elasticsearch/start`
 - Search / indices: `/app/enterprise_search/elasticsearch`
 - Dev Tools console: `/app/dev_tools#/console`

--- a/.agents/skills/kbn-dev/SKILL.md
+++ b/.agents/skills/kbn-dev/SKILL.md
@@ -1,0 +1,234 @@
+---
+name: kbn-dev
+description: >
+  Start, stop, monitor, and interact with local Kibana dev instances
+  (serverless on :5601, stateful on :5611) and their Elasticsearch clusters.
+  Use `yarn kbn-dev` to start and `yarn kbn-dev-ctl` to control.
+  This replaces manually running yarn es + yarn start.
+  Use when the user asks about Kibana status, needs to start or restart
+  Kibana, is debugging startup failures, after code changes that require
+  a Kibana restart, or when working in the kibana repo and the dev
+  environment needs managing. Also use when the user says "start kibana",
+  "startup kibana", "kbn-dev", "run kibana", "kibana dev environment",
+  "start es and kibana", "spin up kibana", "kibana dev", "restart kibana",
+  "check kibana", "kibana logs", "es logs", or "kibana status".
+allowed-tools: >
+  Bash(yarn kbn-dev-ctl *)
+  Bash(yarn kbn-dev *)
+  Bash(curl *)
+  Bash(lsof *)
+  Bash(kill *)
+  Bash(tail *)
+  Bash(grep *)
+---
+
+# Kibana Controller
+
+Manage a local Kibana development environment running two Kibana instances
+(serverless + stateful) against two Elasticsearch clusters, with a shared
+optimizer in watch mode.
+
+## Architecture
+
+```
+kbn-dev (orchestrator, long-running)
+├── ES Serverless  (Docker, port 9200)
+├── ES Stateful    (Docker, port 9201)
+├── Optimizer      (watch mode, shared)
+├── Kibana SLS     (port 5601, serverless mode)
+└── Kibana Stack   (port 5611, stateful mode)
+```
+
+`yarn kbn-dev` is the startup orchestrator. `yarn kbn-dev-ctl` is the control plane.
+
+## Current status
+
+Check status before taking any action:
+
+```
+!`yarn kbn-dev-ctl status --json 2>/dev/null || echo '{"running": false, "state": "not_running"}'`
+```
+
+## UX guidelines — be concise
+
+**Check status first.** The dynamic injection above gives you the current
+state. Handle each case:
+
+- **Already running, both ready**: Tell the user "Kibana is already running"
+  and show the URLs. Do NOT restart unless the user explicitly asks.
+- **Already running, partially ready**: Report what's up and what's down.
+  Offer to restart the failed component.
+- **Running but not ready yet**: A previous session started kbn-dev and it's
+  still booting. Poll for readiness (step 3 below) instead of restarting.
+- **Not running**: Start it (steps 1-5 below).
+
+If the user says "restart kibana", use `yarn kbn-dev-ctl stop` then start fresh.
+
+**Starting Kibana is a background task.** Don't show the user every poll
+cycle. Follow this pattern:
+
+1. Tell the user: "Spinning up serverless and stateful Kibana, standby... (run /kbn-dev-status to check anytime)"
+2. Run `yarn kbn-dev --quiet` in the background (it checks if already running).
+3. Poll silently with a **simple sleep loop** — do NOT show output:
+   ```bash
+   for i in $(seq 1 40); do
+     sleep 15
+     kbn_state=$(yarn kbn-dev-ctl status --json 2>/dev/null)
+     sls=$(echo "$kbn_state" | grep -c '"kbnsls".*"ready": true')
+     stack=$(echo "$kbn_state" | grep -c '"kbnstack".*"ready": true')
+     is_running=$(echo "$kbn_state" | grep -c '"running": true')
+     if [ "$sls" -gt 0 ] && [ "$stack" -gt 0 ]; then break; fi
+     if [ "$is_running" = "0" ] && [ $i -gt 2 ]; then break; fi
+   done
+   ```
+   Important: check `"running": true` — if the orchestrator died (`false`)
+   after a few polls, stop waiting and report the failure.
+   The `state` field goes: `starting` → `es_starting` → `optimizer_ready`
+   → `running`. There is NO `"ready"` state.
+4. Check what came up and tell the user:
+   - Both ready: "Kibana is ready! Serverless: :5601, Stateful: :5611"
+   - Neither ready: "Startup failed. Run `yarn kbn-dev-ctl logs essls --grep ERROR`
+     to see what went wrong."
+   - **Stateful up, Serverless failed**: Tell the user Stateful is ready,
+     then automatically attempt to recover Serverless (see below).
+5. If the `kbn-dev` background process exited early (exit code 0), check
+   `yarn kbn-dev-ctl status --json` — if `"state": "stopped"` or `"state": "failed"`,
+   the orchestrator tore itself down. Check `yarn kbn-dev-ctl logs main --tail 20`
+   for the cause.
+
+### Auto-recover Serverless when Stateful is up
+
+If Stateful comes up but Serverless fails (usually uiam container timeout),
+automatically retry without user intervention:
+
+1. Tell the user: "Stateful is ready at :5611. Serverless failed — retrying..."
+2. Clean up stale serverless containers:
+   ```bash
+   docker rm -f $(docker ps -aq --filter "name=es01" --filter "name=es02" --filter "name=es03" --filter "name=uiam" --filter "name=uiam-cosmosdb") 2>/dev/null
+   ```
+3. Restart the serverless ES cluster from the kibana repo:
+   ```bash
+   yarn es serverless --projectType elasticsearch_general_purpose --clean --kill &
+   ```
+4. Poll `yarn kbn-dev-ctl status --json` for `essls.ready` becoming true (up to 5 min).
+5. Once ES Serverless is ready, start Kibana Serverless:
+   ```bash
+   KBN_OPTIMIZER_USE_MAX_AVAILABLE_RESOURCES=false yarn serverless-es --server.port=5601 --no-optimizer &
+   ```
+6. Poll for `kbnsls.ready` or HTTP 200 on port 5601 (up to 2 min).
+7. Report result: "Serverless is now ready at :5601" or "Serverless
+   recovery failed — uiam may be broken. Try `yarn kbn-dev --quiet --clean`."
+
+Retry this recovery once. If it fails twice, stop and inform the user.
+
+**Never** show raw JSON status output unless the user explicitly asks.
+**Never** show intermediate polling results. One message at the start,
+one message when ready (or failed).
+
+## Commands
+
+| Action | Command |
+|--------|---------|
+| Start | `yarn kbn-dev --quiet` |
+| Start clean | `yarn kbn-dev --quiet --clean` |
+| Start (no EIS) | `KBN_INFERENCE_URL="" yarn kbn-dev --quiet` |
+| Status (JSON) | `yarn kbn-dev-ctl status --json` |
+| Status (human) | `yarn kbn-dev-ctl status` |
+| Logs | `yarn kbn-dev-ctl logs <component> [--tail N] [--grep PATTERN]` |
+| Attach tmux | `yarn kbn-dev-ctl attach` |
+| Restart Kibana | `yarn kbn-dev-ctl restart <kbnsls\|kbnstack>` |
+| Stop | `yarn kbn-dev-ctl stop` |
+
+Components: `essls`, `esstack`, `optimizer`, `kbnsls`, `kbnstack`, `main`, `all`
+
+## When to restart Kibana
+
+Check `yarn kbn-dev-ctl status --json` and restart if a Kibana component shows
+`"alive": false` — common after branch switches, plugin code changes,
+or config edits. The monitor loop in `kbn-dev` auto-restarts after the kill.
+ES clusters and the optimizer stay running.
+
+## Instance details and authentication
+
+| Instance | URL | Login | ES port |
+|----------|-----|-------|---------|
+| Serverless | http://localhost:5601 | auto-login (dev mode) | 9200 |
+| Stateful | http://localhost:5611 | elastic / changeme | 9201 |
+
+### Curl with auth
+
+**Stateful** uses basic auth:
+```bash
+curl -s -u elastic:changeme http://localhost:5611/api/status
+curl -s -u elastic:changeme http://localhost:5611/app/elasticsearch/start
+curl -s -u elastic:changeme "http://localhost:5611/api/console/proxy?path=_cat/indices&method=GET"
+```
+
+**Serverless** in dev mode uses cookie-based auth. First get a session
+cookie, then use it:
+```bash
+# Get session cookie (serverless dev auto-creates a session)
+curl -s -c /tmp/kbn-sls-cookie -L http://localhost:5601/app/home
+# Use the cookie for subsequent requests
+curl -s -b /tmp/kbn-sls-cookie http://localhost:5601/api/status
+curl -s -b /tmp/kbn-sls-cookie http://localhost:5601/app/elasticsearch/start
+```
+
+**ES clusters directly:**
+```bash
+# Serverless ES (port 9200) — no auth in dev
+curl -s http://localhost:9200/_cat/indices?v
+# Stateful ES (port 9201) — basic auth
+curl -s -u elastic:changeme http://localhost:9201/_cat/indices?v
+```
+
+When the user asks "is X working" and you don't have browser tools,
+use curl to fetch the page and check for expected content, API status
+codes, or error messages.
+
+## Failure diagnosis
+
+See [failure-modes.md](failure-modes.md) for detailed patterns. Key fixes:
+- **Node mismatch**: `nvm install $(cat .nvmrc)`
+- **Port in use**: `yarn kbn-dev-ctl restart <component>`
+- **Docker not running**: start Docker
+- **After branch switch**: `yarn kbn-dev --quiet --clean`
+- **Vault failed**: `KBN_INFERENCE_URL="" yarn kbn-dev --quiet`
+
+## Browser interaction
+
+When the user asks about what's visible in Kibana, whether a feature is
+working, or to check/test UI behavior:
+
+1. **If browser tools are available** (e.g. `cursor-ide-browser` MCP),
+   use them to navigate and visually inspect the running instances.
+2. **If no browser tools**, use `curl` with the auth patterns above to
+   fetch pages and check for expected content or error codes.
+
+Do NOT search the codebase for UI questions that can be answered by
+looking at or curling the running app.
+
+- **Serverless** (port 5601): navigate to `http://localhost:5601`.
+  If a login/role selection screen appears, select the **admin** role.
+  The dev serverless setup uses mock authentication — no password needed,
+  just pick the role from the selector.
+- **Stateful** (port 5611): navigate to `http://localhost:5611`.
+  If a login screen appears, enter username `elastic` and password
+  `changeme`. Always use these credentials for stateful.
+
+Common Kibana app paths:
+- Getting started / onboarding: `/app/elasticsearch/start`
+- Search / indices: `/app/enterprise_search/elasticsearch`
+- Dev Tools console: `/app/dev_tools#/console`
+- Discover: `/app/discover`
+- Stack Management: `/app/management`
+- Dashboards: `/app/dashboards`
+
+When the user says "is X working on serverless" or "check the Y page",
+use the browser to navigate there and verify visually.
+
+## Proactive monitoring
+
+After editing `.ts`, `.tsx`, `.yml`, or config files, silently run
+`yarn kbn-dev-ctl status --json`. If a component is down, restart it and tell
+the user briefly: "Kibana SLS crashed, restarting..."

--- a/.agents/skills/kbn-dev/SKILL.md
+++ b/.agents/skills/kbn-dev/SKILL.md
@@ -102,28 +102,13 @@ cycle. Follow this pattern:
 
 ### Auto-recover Serverless when Stateful is up
 
-If Stateful comes up but Serverless fails (usually uiam container timeout),
-automatically retry without user intervention:
+If Stateful comes up but Serverless fails, `kbn-dev` retries serverless
+automatically (up to 3 attempts). If it still fails after the script
+finishes, tell the user:
 
-1. Tell the user: "Stateful is ready at :5611. Serverless failed — retrying..."
-2. Clean up stale serverless containers:
-   ```bash
-   docker rm -f $(docker ps -aq --filter "name=es01" --filter "name=es02" --filter "name=es03" --filter "name=uiam" --filter "name=uiam-cosmosdb") 2>/dev/null
-   ```
-3. Restart the serverless ES cluster from the kibana repo:
-   ```bash
-   yarn es serverless --projectType elasticsearch_general_purpose --clean --kill &
-   ```
-4. Poll `yarn kbn-dev-ctl status --json` for `essls.ready` becoming true (up to 5 min).
-5. Once ES Serverless is ready, start Kibana Serverless:
-   ```bash
-   KBN_OPTIMIZER_USE_MAX_AVAILABLE_RESOURCES=false yarn serverless-es --server.port=5601 --no-optimizer &
-   ```
-6. Poll for `kbnsls.ready` or HTTP 200 on port 5601 (up to 2 min).
-7. Report result: "Serverless is now ready at :5601" or "Serverless
-   recovery failed — uiam may be broken. Try `yarn kbn-dev --quiet --clean`."
-
-Retry this recovery once. If it fails twice, stop and inform the user.
+> "Stateful is ready at :5611. Serverless failed to start — this is
+> usually a Docker state issue. Try `yarn kbn-dev-ctl stop` then
+> `yarn kbn-dev --clean` for a fully clean start."
 
 **Never** show raw JSON status output unless the user explicitly asks.
 **Never** show intermediate polling results. One message at the start,

--- a/.agents/skills/kbn-dev/SKILL.md
+++ b/.agents/skills/kbn-dev/SKILL.md
@@ -1,17 +1,13 @@
 ---
 name: kbn-dev
 description: >
-  Start, stop, monitor, and interact with local Kibana dev instances
-  (serverless on :5601, stateful on :5611) and their Elasticsearch clusters.
-  Use `yarn kbn-dev` to start and `yarn kbn-dev-ctl` to control.
-  This replaces manually running yarn es + yarn start.
-  Use when the user asks about Kibana status, needs to start or restart
-  Kibana, is debugging startup failures, after code changes that require
-  a Kibana restart, or when working in the kibana repo and the dev
-  environment needs managing. Also use when the user says "start kibana",
-  "startup kibana", "kbn-dev", "run kibana", "kibana dev environment",
-  "start es and kibana", "spin up kibana", "kibana dev", "restart kibana",
-  "check kibana", "kibana logs", "es logs", or "kibana status".
+  Start, stop, restart, and manage local Kibana dev instances (serverless
+  on :5601, stateful on :5611). Use when the user wants to start kibana,
+  restart kibana, stop kibana, view logs, or debug startup failures.
+  Trigger words: "start kibana", "restart kibana", "stop kibana",
+  "kbn-dev", "spin up kibana", "kibana logs", "es logs".
+  For status-only queries ("is kibana running", "kibana status"), prefer
+  the /kbn-dev-status skill instead.
 allowed-tools: >
   Bash(source * && yarn kbn-dev-ctl *)
   Bash(source * && yarn kbn-dev *)
@@ -24,77 +20,52 @@ allowed-tools: >
   Bash(grep *)
 ---
 
-# Kibana Controller
+# Kibana Dev Environment
 
-Manage a local Kibana development environment running two Kibana instances
-(serverless + stateful) against two Elasticsearch clusters, with a shared
-optimizer in watch mode.
+Dual-mode Kibana dev launcher: serverless (:5601) + stateful (:5611).
 
-## Architecture
+`yarn kbn-dev` starts everything. `yarn kbn-dev-ctl` controls it.
 
-```
-kbn-dev (orchestrator, long-running)
-├── ES Serverless  (Docker, port 9200)
-├── ES Stateful    (Docker, port 9201)
-├── Optimizer      (watch mode, shared)
-├── Kibana SLS     (port 5601, serverless mode)
-└── Kibana Stack   (port 5611, stateful mode)
-```
+**All commands must run from the kibana repo root.** Verify before
+running: `grep -q '"name": "kibana"' package.json 2>/dev/null || echo "NOT in kibana root — cd there first"`
 
-`yarn kbn-dev` is the startup orchestrator. `yarn kbn-dev-ctl` is the control plane.
+## nvm — MUST prefix all yarn commands
 
-## IMPORTANT: nvm required before yarn commands
-
-Agent shells don't load nvm, so the system node version won't match kibana's
-`.nvmrc`. Yarn's engine check rejects commands before the script even runs.
-**Always source nvm before any yarn command:**
+Agent shells don't load nvm. Yarn rejects commands if node doesn't match
+`.nvmrc`. **Prefix every yarn call with:**
 
 ```bash
-source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use && nvm use --silent && yarn kbn-dev-ctl ...
+source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use && nvm use --silent && yarn ...
 ```
 
-Shorthand used throughout this skill: `nvm_use` = `source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use && nvm use --silent`
-
-Every `yarn` invocation below MUST be prefixed with this. If you run a
-bare `yarn kbn-dev-ctl` without sourcing nvm first, it will fail with
-"The engine node is incompatible".
+Source nvm once per shell session, then run yarn commands normally.
 
 ## Current status
-
-Check status before taking any action:
 
 ```
 !`source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use 2>/dev/null && nvm use --silent 2>/dev/null; yarn kbn-dev-ctl status --json 2>/dev/null || echo '{"running": false, "state": "not_running"}'`
 ```
 
-## UX guidelines — be concise
+## Commands
 
-**Check status first.** The dynamic injection above gives you the current
-state. The key fields are `"running"` (is the orchestrator PID alive) and
-`"state"` (what phase it's in). Handle each case:
+| Action | Command |
+|--------|---------|
+| Start | `yarn kbn-dev --quiet` |
+| Start clean | `yarn kbn-dev --quiet --clean` |
+| Status | `yarn kbn-dev-ctl status --json` |
+| Logs | `yarn kbn-dev-ctl logs <component> [--tail N] [--grep PAT]` |
+| Restart | `yarn kbn-dev-ctl restart <serverless\|stateful\|all>` |
+| Stop | `yarn kbn-dev-ctl stop` |
 
-- **`"running": true`, both kbnsls and kbnstack show `"ready": true`**:
-  Tell the user "Kibana is already running" and show the URLs. Do NOT
-  restart unless the user explicitly asks.
-- **`"running": true`, state is `"starting"` / `"es_starting"` / `"optimizer_ready"`**:
-  Kibana is already starting up (from this or a previous session). Tell
-  the user "Kibana is currently starting up (state: X). I'll monitor it."
-  Then poll for readiness (step 3 below). Do NOT start a second instance.
-- **`"running": true`, partially ready (one up, one down)**:
-  Report what's up and what's down. Offer to restart the failed component.
-- **`"running": false`**: Start it (steps 1-5 below).
+Components: `essls`, `esstack`, `optimizer`, `kbnsls`, `kbnstack`, `main`, `all`
 
-If the user says "restart kibana", use `yarn kbn-dev-ctl restart all`.
-Restart does a full stop + start (ES + Kibana together). It backgrounds
-the new kbn process and returns immediately. **After a restart, always
-poll for readiness using the same loop as step 3 below.**
+## Starting Kibana
 
-**Starting Kibana is a background task.** Don't show the user every poll
-cycle. Follow this pattern:
+Check status first. If already running, tell the user. If not:
 
-1. Tell the user: "Spinning up serverless and stateful Kibana, standby... (run /kbn-dev-status to check anytime)"
-2. Run `yarn kbn-dev --quiet` in the background (it checks if already running).
-3. Poll silently with a **simple sleep loop** — do NOT show output:
+1. Say: "Spinning up Kibana, standby... (run /kbn-dev-status to check)"
+2. Run `yarn kbn-dev --quiet` in background.
+3. Poll silently:
    ```bash
    source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use && nvm use --silent
    for i in $(seq 1 40); do
@@ -107,197 +78,47 @@ cycle. Follow this pattern:
      if [ "$is_running" = "0" ] && [ $i -gt 2 ]; then break; fi
    done
    ```
-   Important: check `"running": true` — if the orchestrator died (`false`)
-   after a few polls, stop waiting and report the failure.
-   The `state` field goes: `starting` → `es_starting` → `optimizer_ready`
-   → `running`. There is NO `"ready"` state.
-4. Check what came up and tell the user:
-   - Both ready: "Kibana is ready! Serverless: :5601, Stateful: :5611"
-   - Neither ready: "Startup failed. Run `yarn kbn-dev-ctl logs essls --grep ERROR`
-     to see what went wrong."
-   - **Stateful up, Serverless failed**: Tell the user Stateful is ready,
-     then automatically attempt to recover Serverless (see below).
-5. If the `kbn-dev` background process exited early (exit code 0), check
-   `yarn kbn-dev-ctl status --json` — if `"state": "stopped"` or `"state": "failed"`,
-   the orchestrator tore itself down. Check `yarn kbn-dev-ctl logs main --tail 20`
-   for the cause.
+4. Report: both ready → URLs. Neither → "check logs". One failed → offer restart.
 
-### Auto-recover Serverless when Stateful is up
+State progression: `starting` → `es_starting` → `optimizer_ready` → `running`.
 
-If Stateful comes up but Serverless fails, `kbn-dev` retries serverless
-automatically (up to 3 attempts). If it still fails after the script
-finishes, tell the user:
+**Never** show raw JSON or intermediate polls. One message at start, one when done.
 
-> "Stateful is ready at :5611. Serverless failed to start — this is
-> usually a Docker state issue. Try `yarn kbn-dev-ctl stop` then
-> `yarn kbn-dev --clean` for a fully clean start."
+## Viewing logs
 
-**Never** show raw JSON status output unless the user explicitly asks.
-**Never** show intermediate polling results. One message at the start,
-one message when ready (or failed).
+**"Open the logs":** Requires interactive terminal. Tell the user:
+> Run `yarn kbn-dev-ctl attach` in your terminal.
 
-## Commands
-
-All commands must be prefixed with nvm sourcing (see above). Source nvm
-once at the start of a shell session, then run yarn commands normally.
-
-| Action | Command |
-|--------|---------|
-| Start | `yarn kbn-dev --quiet` |
-| Start clean | `yarn kbn-dev --quiet --clean` |
-| Start (no EIS) | `KBN_INFERENCE_URL="" yarn kbn-dev --quiet` |
-| Status (JSON) | `yarn kbn-dev-ctl status --json` |
-| Status (human) | `yarn kbn-dev-ctl status` |
-| Logs | `yarn kbn-dev-ctl logs <component> [--tail N] [--grep PATTERN]` |
-| Attach tmux | `yarn kbn-dev-ctl attach` |
-| Restart | `yarn kbn-dev-ctl restart <serverless\|stateful\|all>` |
-| Stop | `yarn kbn-dev-ctl stop` |
-
-Components: `essls`, `esstack`, `optimizer`, `kbnsls`, `kbnstack`, `main`, `all`
-
-### Viewing logs
-
-**"Open the logs" / "show me all logs":**
-The tmux log viewer requires an interactive terminal, so you can't attach
-to it directly. Tell the user to run it themselves:
-
-> Run `yarn kbn-dev-ctl attach` in your terminal to open the tmux log
-> viewer with all four panes (ES Serverless, ES Stateful, Kibana SLS,
-> Kibana Stack).
-
-**Showing logs inline (what you CAN do):**
-Use `yarn kbn-dev-ctl logs <component>` to show logs in the agent shell.
-This works for targeted requests like "show me serverless errors":
-
+**Inline logs (what you CAN do):**
 ```bash
-yarn kbn-dev-ctl logs kbnsls --tail 50              # last 50 lines
-yarn kbn-dev-ctl logs all --grep "ERROR|FATAL"       # errors across all
-yarn kbn-dev-ctl logs essls --tail 20 --grep error   # ES serverless errors
+yarn kbn-dev-ctl logs kbnsls --tail 50
+yarn kbn-dev-ctl logs all --grep "ERROR|FATAL"
 ```
 
-Do NOT try to open terminal tabs, run AppleScript, or `tail -f` manually.
+Do NOT open terminal tabs, run AppleScript, or `tail -f` manually.
 
-## When to restart
+## Failure quick-ref
 
-Check `yarn kbn-dev-ctl status --json` and restart if a component shows
-`"alive": false` — common after branch switches, plugin code changes,
-or config edits. Restart always does a full stop + start (ES + Kibana
-together), never just Kibana alone.
-
-```bash
-yarn kbn-dev-ctl restart serverless   # restart ES Serverless + Kibana SLS
-yarn kbn-dev-ctl restart stateful     # restart ES Stateful + Kibana Stack
-yarn kbn-dev-ctl restart all          # restart everything
-```
-
-## Instance details and authentication
-
-| Instance | URL | Login | ES port |
-|----------|-----|-------|---------|
-| Serverless | http://localhost:5601 | auto-login (dev mode) | 9200 |
-| Stateful | http://localhost:5611 | elastic / changeme | 9201 |
-
-### Curl with auth
-
-**Stateful** uses basic auth:
-```bash
-curl -s -u elastic:changeme http://localhost:5611/api/status
-curl -s -u elastic:changeme http://localhost:5611/app/elasticsearch/start
-curl -s -u elastic:changeme "http://localhost:5611/api/console/proxy?path=_cat/indices&method=GET"
-```
-
-**Serverless** in dev mode uses cookie-based auth. First get a session
-cookie, then use it:
-```bash
-# Get session cookie (serverless dev auto-creates a session)
-curl -s -c /tmp/kbn-sls-cookie -L http://localhost:5601/app/home
-# Use the cookie for subsequent requests
-curl -s -b /tmp/kbn-sls-cookie http://localhost:5601/api/status
-curl -s -b /tmp/kbn-sls-cookie http://localhost:5601/app/elasticsearch/start
-```
-
-**ES clusters directly:**
-```bash
-# Serverless ES (port 9200) — no auth in dev
-curl -s http://localhost:9200/_cat/indices?v
-# Stateful ES (port 9201) — basic auth
-curl -s -u elastic:changeme http://localhost:9201/_cat/indices?v
-```
-
-When the user asks "is X working" and you don't have browser tools,
-use curl to fetch the page and check for expected content, API status
-codes, or error messages.
-
-## Failure diagnosis
-
-See [failure-modes.md](failure-modes.md) for detailed patterns. Key fixes:
 - **Node mismatch**: `nvm install $(cat .nvmrc)`
 - **Port in use**: `yarn kbn-dev-ctl restart all`
 - **Docker not running**: start Docker
 - **After branch switch**: `yarn kbn-dev --quiet --clean`
 - **Vault failed**: `KBN_INFERENCE_URL="" yarn kbn-dev --quiet`
 
-## Browser interaction
+For detailed diagnosis, read [failure-modes.md](failure-modes.md).
 
-When the user asks about what's visible in Kibana, whether a feature is
-working, or to check/test UI behavior:
+## Auth & browser interaction
 
-1. **If browser tools are available** (e.g. `cursor-ide-browser` MCP),
-   use them to navigate and visually inspect the running instances.
-2. **If no browser tools**, use `curl` with the auth patterns above to
-   fetch pages and check for expected content or error codes.
+For login screens, curl auth examples, and browser automation guidance,
+read [browser-auth.md](browser-auth.md).
 
-Do NOT search the codebase for UI questions that can be answered by
-looking at or curling the running app.
-
-### Handling login screens
-
-When you navigate to a Kibana instance and see a login/auth screen
-instead of the expected page, handle it automatically:
-
-**Serverless (port 5601) — Role selector:**
-The dev serverless instance uses mock authentication. Instead of a
-username/password form, you'll see a **role selection page** with
-profile cards for different roles (e.g. `admin`, `editor`, `viewer`,
-`t1_analyst`, `t2_analyst`, etc.).
-- Look for a card/button labeled **"admin"** (or containing "admin"
-  in the role name) and click it.
-- Default to `admin` unless the user specifically requests a different
-  role.
-- After selecting a role, you'll be redirected to the Kibana app. If
-  you land on a space selector, pick **Default** space.
-- There is no password. Just select the role.
-
-**Stateful (port 5611) — Login form:**
-The stateful instance uses a standard login form.
-- Find the **username** input field and type: `elastic`
-- Find the **password** input field and type: `changeme`
-- Click the **"Log in"** button.
-- If you see an "Enter code" or enrollment screen instead, the ES
-  cluster may not be configured correctly — report this to the user.
-
-**Detecting auth screens:**
-- If the URL contains `/login` or the page shows "Log in to Elastic"
-  or a role selector grid, you're on an auth page.
-- If you see a 401 or "Unauthorized" response, the session expired —
-  repeat the login flow.
-- After successful auth, navigate to the originally requested URL.
-
-### Common Kibana app paths
-
-- Getting started / onboarding: `/app/elasticsearch/start`
-- Search / indices: `/app/enterprise_search/elasticsearch`
-- Dev Tools console: `/app/dev_tools#/console`
-- Discover: `/app/discover`
-- Stack Management: `/app/management`
-- Dashboards: `/app/dashboards`
-
-When the user says "is X working on serverless" or "check the Y page",
-use the browser to navigate there and verify visually.
+| Instance | URL | Login |
+|----------|-----|-------|
+| Serverless | http://localhost:5601 | select "admin" role (no password) |
+| Stateful | http://localhost:5611 | elastic / changeme |
 
 ## Proactive monitoring
 
 After editing `.ts`, `.tsx`, `.yml`, or config files, silently run
-`yarn kbn-dev-ctl status --json`. If a component is down, run
-`yarn kbn-dev-ctl restart serverless` (or `stateful`) and tell the user
-briefly: "Kibana SLS crashed, restarting..."
+`yarn kbn-dev-ctl status --json`. If a component is down, restart and
+tell the user briefly: "Kibana SLS crashed, restarting..."

--- a/.agents/skills/kbn-dev/SKILL.md
+++ b/.agents/skills/kbn-dev/SKILL.md
@@ -67,7 +67,9 @@ state. The key fields are `"running"` (is the orchestrator PID alive) and
 - **`"running": false`**: Start it (steps 1-5 below).
 
 If the user says "restart kibana", use `yarn kbn-dev-ctl restart all`.
-Restart always does a full stop + start (ES + Kibana together).
+Restart does a full stop + start (ES + Kibana together). It backgrounds
+the new kbn process and returns immediately. **After a restart, always
+poll for readiness using the same loop as step 3 below.**
 
 **Starting Kibana is a background task.** Don't show the user every poll
 cycle. Follow this pattern:

--- a/.agents/skills/kbn-dev/browser-auth.md
+++ b/.agents/skills/kbn-dev/browser-auth.md
@@ -1,0 +1,66 @@
+# Browser Interaction & Authentication
+
+## Handling login screens
+
+When you navigate to a Kibana instance and see a login/auth screen
+instead of the expected page, handle it automatically:
+
+### Serverless (port 5601) — Role selector
+
+The dev serverless instance uses mock authentication. Instead of a
+username/password form, you'll see a **role selection page** with
+profile cards for different roles (e.g. `admin`, `editor`, `viewer`,
+`t1_analyst`, `t2_analyst`, etc.).
+- Look for a card/button labeled **"admin"** (or containing "admin"
+  in the role name) and click it.
+- Default to `admin` unless the user specifically requests a different role.
+- After selecting a role, you'll be redirected to the Kibana app. If
+  you land on a space selector, pick **Default** space.
+- There is no password. Just select the role.
+
+### Stateful (port 5611) — Login form
+
+The stateful instance uses a standard login form.
+- Find the **username** input field and type: `elastic`
+- Find the **password** input field and type: `changeme`
+- Click the **"Log in"** button.
+- If you see an "Enter code" or enrollment screen instead, the ES
+  cluster may not be configured correctly — report this to the user.
+
+### Detecting auth screens
+
+- If the URL contains `/login` or the page shows "Log in to Elastic"
+  or a role selector grid, you're on an auth page.
+- If you see a 401 or "Unauthorized" response, the session expired —
+  repeat the login flow.
+- After successful auth, navigate to the originally requested URL.
+
+## Curl with auth
+
+**Stateful** uses basic auth:
+```bash
+curl -s -u elastic:changeme http://localhost:5611/api/status
+curl -s -u elastic:changeme http://localhost:5611/app/elasticsearch/start
+curl -s -u elastic:changeme "http://localhost:5611/api/console/proxy?path=_cat/indices&method=GET"
+```
+
+**Serverless** in dev mode uses cookie-based auth:
+```bash
+curl -s -c /tmp/kbn-sls-cookie -L http://localhost:5601/app/home
+curl -s -b /tmp/kbn-sls-cookie http://localhost:5601/api/status
+```
+
+**ES clusters directly:**
+```bash
+curl -s http://localhost:9200/_cat/indices?v                        # serverless ES
+curl -s -u elastic:changeme http://localhost:9201/_cat/indices?v    # stateful ES
+```
+
+## Common Kibana app paths
+
+- Getting started / onboarding: `/app/elasticsearch/start`
+- Search / indices: `/app/enterprise_search/elasticsearch`
+- Dev Tools console: `/app/dev_tools#/console`
+- Discover: `/app/discover`
+- Stack Management: `/app/management`
+- Dashboards: `/app/dashboards`

--- a/.agents/skills/kbn-dev/failure-modes.md
+++ b/.agents/skills/kbn-dev/failure-modes.md
@@ -39,14 +39,17 @@ yarn kbn-dev-ctl logs essls --grep "error"   # check specific error
 **Symptom:** Log shows `Waiting for "uiam" container (unhealthy)` then
 `The "uiam" container failed to start within the expected time`.
 
-**Cause:** Stale Docker containers from a previous failed serverless run.
-`kbn-dev` cleans these automatically on startup, but if you hit this mid-session:
+**Cause:** Stale Docker network or containers from a previous run. The
+`elastic` Docker network accumulates stale DNS entries from crashed
+containers, causing uiam to fail resolving cosmosdb. `kbn-dev` cleans
+containers and the network automatically on startup, and retries up to
+3 times.
 
-**Fix:**
+**Fix if it persists:**
 ```bash
-docker rm -f $(docker ps -aq --filter "ancestor=docker.elastic.co/kibana-ci/uiam:latest-verified") 2>/dev/null
-docker rm -f $(docker ps -aq --filter "ancestor=docker.elastic.co/kibana-ci/elasticsearch-serverless:latest-verified") 2>/dev/null
-docker rm -f $(docker ps -aq --filter "ancestor=docker.elastic.co/kibana-ci/uiam-azure-cosmos-emulator:latest-verified") 2>/dev/null
+yarn kbn-dev-ctl stop
+docker system prune -a    # nuclear option: clears all Docker state
+yarn kbn-dev
 ```
 
 ### Bootstrap fails

--- a/.agents/skills/kbn-dev/failure-modes.md
+++ b/.agents/skills/kbn-dev/failure-modes.md
@@ -1,0 +1,151 @@
+# Kibana Controller — Failure Modes
+
+Reference for diagnosing and fixing common kbn-dev startup and runtime failures.
+
+## Startup failures
+
+### All processes die immediately
+
+**Symptom:** `yarn kbn-dev-ctl status` shows everything down, logs are nearly empty.
+
+**Likely cause:** Wrong Node.js version. The subshells picked up a system
+node instead of the nvm-managed version.
+
+**Fix:**
+```bash
+yarn kbn-dev-ctl logs main --grep "incompatible\|Expected version"
+# If node mismatch: nvm install $(cat .nvmrc) && nvm use
+```
+
+### ES clusters fail to start
+
+**Symptom:** `essls` or `esstack` shows `"alive": false` within seconds.
+
+**Likely causes:**
+1. Docker not running — `docker ps` fails
+2. Ports 9200/9300 occupied — OrbStack, another ES instance, etc.
+3. Cache corruption — stale `.es/cache` directory
+4. Stale kibana-ci containers — `uiam` or ES containers from a previous run
+
+**Fix:**
+```bash
+docker ps                                    # verify Docker is running
+yarn kbn-dev-ctl logs essls --grep "error"   # check specific error
+# Restart with clean: yarn kbn-dev --clean
+```
+
+### uiam container fails to start (serverless)
+
+**Symptom:** Log shows `Waiting for "uiam" container (unhealthy)` then
+`The "uiam" container failed to start within the expected time`.
+
+**Cause:** Stale Docker containers from a previous failed serverless run.
+`kbn-dev` cleans these automatically on startup, but if you hit this mid-session:
+
+**Fix:**
+```bash
+docker rm -f $(docker ps -aq --filter "ancestor=docker.elastic.co/kibana-ci/uiam:latest-verified") 2>/dev/null
+docker rm -f $(docker ps -aq --filter "ancestor=docker.elastic.co/kibana-ci/elasticsearch-serverless:latest-verified") 2>/dev/null
+docker rm -f $(docker ps -aq --filter "ancestor=docker.elastic.co/kibana-ci/uiam-azure-cosmos-emulator:latest-verified") 2>/dev/null
+```
+
+### Bootstrap fails
+
+**Symptom:** Status stuck at `"state": "starting"`, optimizer never starts.
+
+**Likely causes:**
+1. Missing dependencies after branch switch
+2. Corrupted node_modules
+3. Yarn cache issues
+
+**Fix:**
+```bash
+yarn kbn-dev-ctl logs main --tail 100       # check bootstrap output
+# Clean rebuild:
+yarn kbn-dev-ctl stop
+yarn kbn clean && yarn kbn bootstrap
+yarn kbn-dev --quiet &
+```
+
+### Optimizer dies
+
+**Symptom:** `optimizer` shows `"alive": false`, Kibana processes never start.
+
+**Likely cause:** Build errors in plugin code, out-of-memory.
+
+**Fix:**
+```bash
+yarn kbn-dev-ctl logs optimizer --tail 100
+# Usually requires fixing the code error, then:
+yarn kbn-dev-ctl stop
+yarn kbn-dev --quiet &
+```
+
+## Runtime failures
+
+### Kibana crashes after branch switch
+
+**Symptom:** `FATAL: Cannot find module '@kbn/...'`
+
+**Fix:**
+```bash
+yarn kbn-dev-ctl stop
+yarn kbn-dev --quiet --clean &
+```
+
+### Port already in use
+
+**Symptom:** `FATAL Error: Port 5601 is already in use`
+
+**Fix:**
+```bash
+yarn kbn-dev-ctl restart kbnsls   # or kbnstack for port 5611
+```
+
+The restart command kills the orphaned process and the monitor loop
+restarts Kibana automatically.
+
+### Kibana running but not responding
+
+**Symptom:** Port is open but `curl` times out or returns 503.
+
+**Check:**
+```bash
+yarn kbn-dev-ctl logs kbnsls --tail 20 --grep "status\|ERROR\|FATAL"
+curl -s -o /dev/null -w "%{http_code}" http://localhost:5601/api/status
+```
+
+If the status API returns 503, Kibana is still initializing plugins.
+Wait and re-check. If it persists, restart.
+
+### EIS / Vault failures
+
+**Symptom:** Vault access fails in non-interactive mode, or `node scripts/eis.js`
+errors in the main log.
+
+**Fix:**
+```bash
+# Option 1: disable EIS entirely
+KBN_INFERENCE_URL="" yarn kbn-dev --quiet &
+
+# Option 2: provide API key directly
+export KIBANA_EIS_CCM_API_KEY="your-key-here"
+yarn kbn-dev --quiet &
+
+# Option 3: log in to vault first (interactive terminal)
+VAULT_ADDR=https://secrets.elastic.co:8200 vault login -method oidc
+```
+
+## Log patterns to grep
+
+| Pattern | Meaning |
+|---------|---------|
+| `succ Serverless ES cluster running` | ES Serverless ready |
+| `succ ES cluster is ready` | ES Stateful ready |
+| `succ.*bundles compiled successfully` | Optimizer build done |
+| `succ all bundles cached` | Optimizer using cache |
+| `[INFO ][status] Kibana is now available` | Kibana accepting requests |
+| `FATAL` | Unrecoverable error |
+| `server crashed` | Kibana process died |
+| `Port .* is already in use` | Orphaned process on port |
+| `Cannot find module` | Missing dependency (needs bootstrap) |

--- a/.agents/skills/kbn-dev/failure-modes.md
+++ b/.agents/skills/kbn-dev/failure-modes.md
@@ -8,13 +8,15 @@ Reference for diagnosing and fixing common kbn-dev startup and runtime failures.
 
 **Symptom:** `yarn kbn-dev-ctl status` shows everything down, logs are nearly empty.
 
-**Likely cause:** Wrong Node.js version. The subshells picked up a system
-node instead of the nvm-managed version.
+**Likely cause:** Wrong Node.js version. Agent shells don't load nvm, so
+the system node doesn't match kibana's `.nvmrc`.
 
 **Fix:**
 ```bash
+# Source nvm first (required for all yarn commands in agent shells)
+source "${NVM_DIR:-$HOME/.nvm}/nvm.sh" --no-use && nvm use --silent
 yarn kbn-dev-ctl logs main --grep "incompatible\|Expected version"
-# If node mismatch: nvm install $(cat .nvmrc) && nvm use
+# If node mismatch: nvm install $(cat .nvmrc)
 ```
 
 ### ES clusters fail to start

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 ## Setup
 - Run `yarn kbn bootstrap` for initial setup, after switching branches, or when encountering dependency errors
+- Use `yarn kbn-dev` to start the dual-mode dev environment (serverless + stateful). See `/kbn-dev` skill.
 
 ## Overview
 - Kibana is organized into modules, each defined by a `kibana.jsonc`: core, packages, and plugin packages. Aside from tooling and testing, most code lives in these modules.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "es": "node scripts/es",
     "preinstall": "node ./preinstall_check",
     "kbn": "node scripts/kbn",
+    "kbn-dev": "bash scripts/kbn_dev.sh",
+    "kbn-dev-ctl": "bash scripts/kbn_dev_ctl.sh",
     "lint": "yarn run lint:es && yarn run lint:style",
     "lint:es": "node scripts/eslint_all_files",
     "lint:oxc": "node scripts/lint",

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -674,26 +674,22 @@ log_step "Starting ES Serverless..." "$ESSLS_LOG"
   yarn es serverless \
     --projectType elasticsearch_general_purpose \
     --clean --kill \
-    $INFERENCE_FLAG &
-  ES_SLS_PID=$!
+    $INFERENCE_FLAG
+  es_exit=$?
 
-  # Wait for cosmosdb to become healthy, then let yarn es continue
-  sleep 5
-  wait_for_cosmosdb
-
-  # If uiam crashed because cosmosdb wasn't ready, restart just uiam
-  if ! docker inspect -f '{{.State.Running}}' uiam 2>/dev/null | grep -q true; then
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] uiam is not running — restarting it"
+  # If the first attempt failed (uiam crashed because cosmosdb wasn't ready),
+  # cosmosdb and ES nodes may still be running. Wait for cosmosdb to be
+  # healthy, remove just the crashed uiam, and retry without --clean --kill
+  # so the healthy containers are preserved.
+  if [ $es_exit -ne 0 ]; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless failed (exit $es_exit). Checking cosmosdb..."
+    wait_for_cosmosdb
     docker rm -f uiam 2>/dev/null || true
-    # Trigger yarn es to restart uiam by killing and re-running
-    kill $ES_SLS_PID 2>/dev/null || true
-    wait $ES_SLS_PID 2>/dev/null || true
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Retrying ES Serverless (preserving healthy containers)..."
     # shellcheck disable=SC2086
     yarn es serverless \
       --projectType elasticsearch_general_purpose \
       $INFERENCE_FLAG
-  else
-    wait $ES_SLS_PID
   fi
 ) >> "$ESSLS_LOG" 2>&1 &
 ESSLS_PID=$!

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -1,0 +1,916 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+# kbn-dev — spin up Kibana + Elasticsearch for both serverless and stateful
+#
+# Run from the ROOT of your kibana repo checkout:
+#   yarn kbn-dev
+#
+# Optional environment variables:
+#   CHROME_BIN            Path to Google Chrome executable. Auto-detected if
+#                         not set (checks standard macOS/Linux locations).
+#                         Override: export CHROME_BIN="/path/to/google-chrome"
+#   KBN_LOG_DIR           Directory for log files.
+#                         Default: ~/.kbn/logs
+#   KBN_INFERENCE_URL     Elastic inference service URL.
+#                         Default: "https://inference.eu-west-1.aws.svc.qa.elastic.cloud"
+#                         Set to "" to disable EIS entirely.
+#                         When enabled, vault access is verified upfront and
+#                         'node scripts/eis.js' runs after each ES cluster is ready.
+#   KIBANA_EIS_CCM_API_KEY  If set, this API key is used directly and vault is
+#                         skipped. Useful for CI or when vault is unavailable.
+#   SKIP_BROWSER_LAUNCH   Set to any value to skip Chrome profile setup and
+#                         browser launch entirely.
+#
+# Flags:
+#   --clean               Wipe .es/cache and run `yarn kbn clean` before boot.
+#   --quiet               Skip the tmux log viewer (on by default).
+#
+# Prerequisites:
+#   - Node.js (nvm is detected automatically if installed)
+#   - yarn (ships with the kibana repo via corepack/volta/etc.)
+#   - Docker running (required by `yarn es`)
+#   - Google Chrome (auto-detected, or set CHROME_BIN)
+#   - Ports 5601, 5611, 9200, 9201, 9300, 9301 must be free
+#   - vault CLI (for EIS; skip with KIBANA_EIS_CCM_API_KEY or KBN_INFERENCE_URL="")
+# ---------------------------------------------------------------------------
+
+# --- Detect interactive mode ------------------------------------------------
+# Non-interactive when stdin is not a terminal (piped, run by agent, CI, etc.).
+# Interactive prompts auto-accept and verbose banners are suppressed.
+INTERACTIVE=true
+[ -t 0 ] || INTERACTIVE=false
+
+# =============================================================================
+# Utility functions
+# =============================================================================
+
+log_step() {
+  local msg="$1"
+  local logfile="${2:-}"
+  local line
+  line="[$(date '+%Y-%m-%d %H:%M:%S')] $msg"
+  echo -e "\n$line"
+  [ -n "$logfile" ] && echo -e "\n$line" >> "$logfile"
+}
+
+wait_for_log() {
+  local logfile="$1" pattern="$2" pid="$3" label="$4"
+  while true; do
+    grep -q "$pattern" "$logfile" 2>/dev/null && return 0
+    if [ -n "$pid" ] && ! kill -0 "$pid" 2>/dev/null; then
+      log_step "ERROR: $label process died. Check $logfile"
+      return 1
+    fi
+    sleep 2
+  done
+}
+
+wait_for_kibana() {
+  local label="$1" logfile="$2" es_pid="$3" kbn_pidfile="$4" port="${5:-}"
+  local kbn_pid
+
+  log_step "Waiting for $label to become available..."
+  while true; do
+    if grep -q "\[INFO \]\[status\] Kibana is now available" "$logfile" 2>/dev/null; then
+      log_step "$label is available!"
+      return 0
+    fi
+    # Also check via HTTP — the log grep can miss if log is buffered
+    if [ -n "$port" ]; then
+      local http_code
+      http_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$port/api/status" 2>/dev/null || echo "000")
+      if [ "$http_code" = "200" ] || [ "$http_code" = "302" ]; then
+        log_step "$label is available! (detected via HTTP $http_code)"
+        return 0
+      fi
+    fi
+    if ! kill -0 "$es_pid" 2>/dev/null && [ ! -f "$kbn_pidfile" ]; then
+      log_step "FAILED: ES died and $label was never started."
+      return 1
+    fi
+    if [ -f "$kbn_pidfile" ]; then
+      kbn_pid=$(cat "$kbn_pidfile" 2>/dev/null)
+      if [ -n "$kbn_pid" ] && ! kill -0 "$kbn_pid" 2>/dev/null; then
+        # Double-check: the monitor PID might be orphaned from the pipeline
+        # subshell. Check if the port is listening as a fallback.
+        if [ -n "$port" ] && lsof -ti "tcp:$port" >/dev/null 2>&1; then
+          sleep 2
+          continue
+        fi
+        log_step "FAILED: $label monitor died. Check $logfile"
+        return 1
+      fi
+    fi
+    sleep 2
+  done
+}
+
+kill_tree() {
+  local pid="$1"
+  if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+    pkill -P "$pid" 2>/dev/null || true
+    kill "$pid" 2>/dev/null || true
+  fi
+}
+
+kill_port() {
+  local port="$1"
+  local pid
+  pid=$(lsof -ti "tcp:$port" 2>/dev/null)
+  if [ -n "$pid" ]; then
+    log_step "Clearing stale process $pid on port $port"
+    kill -9 "$pid" 2>/dev/null || true
+    sleep 1
+  fi
+}
+
+write_status() {
+  local state="$1"
+  shift
+  local ts
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+  cat > "$LOG_DIR/status.json" <<STATUSEOF
+{
+  "state": "$state",
+  "updated": "$ts",
+  "pid": $$,
+  "log_dir": "$LOG_DIR",
+  "kbn_dir": "$KBN_DIR",
+  "clean": $CLEAN_CACHE,
+  "eis": $([ -n "$INFERENCE_FLAG" ] && echo "true" || echo "false"),
+  "components": {
+    "essls":     { "pid": "${ESSLS_PID:-null}",     "log": "$ESSLS_LOG",     "port": 9200 },
+    "esstack":   { "pid": "${ESSTACK_PID:-null}",   "log": "$ESSTACK_LOG",   "port": 9201 },
+    "optimizer": { "pid": "${OPTIMIZER_PID:-null}",  "log": "$OPTIMIZER_LOG"  },
+    "kbnsls":    { "pid": "${KBNSLS_PID:-null}",    "log": "$KBNSLS_LOG",    "port": 5601, "url": "http://localhost:5601" },
+    "kbnstack":  { "pid": "${KBNSTACK_PID:-null}",  "log": "$KBNSTACK_LOG",  "port": 5611, "url": "http://localhost:5611" }
+  }$([ $# -gt 0 ] && echo ","; for kv in "$@"; do echo "  $kv"; done)
+}
+STATUSEOF
+}
+
+# =============================================================================
+# Pre-flight checks (before anything starts)
+# =============================================================================
+
+# --- Intro banner (interactive only) ----------------------------------------
+if [ "$INTERACTIVE" = true ]; then
+  cat <<'BANNER'
+
+=============================================
+ kbn-dev — Kibana dual-mode dev launcher
+=============================================
+
+ Spins up Elasticsearch (serverless + stateful) and two Kibana
+ instances in parallel, with an optimizer in watch mode.
+
+ Prerequisites:
+   Node.js    nvm is detected automatically from .nvmrc
+   yarn       ships with the kibana repo (corepack/volta)
+   Docker     required by 'yarn es' for ES clusters
+   Chrome     auto-detected, or set CHROME_BIN
+   vault      required for EIS (skip with KIBANA_EIS_CCM_API_KEY
+              or KBN_INFERENCE_URL="")
+
+ Environment variables:
+   KBN_INFERENCE_URL        EIS inference service URL
+   KIBANA_EIS_CCM_API_KEY   Provide EIS API key directly (skips vault)
+   CHROME_BIN               Path to Chrome binary (auto-detected if unset)
+   KBN_LOG_DIR              Log directory. Default: ~/.kbn/logs
+   SKIP_BROWSER_LAUNCH      Set to any value to skip Chrome launch
+
+ Flags:
+   --clean                  Wipe .es/cache and run 'yarn kbn clean'
+   --quiet                  Skip the tmux log viewer (on by default)
+
+=============================================
+
+BANNER
+fi
+
+# --- Repo root check -------------------------------------------------------
+if [ ! -f "package.json" ] || ! grep -q '"name": "kibana"' package.json 2>/dev/null; then
+  echo "ERROR: This script must be run from the root of the kibana repo."
+  echo "  yarn kbn-dev"
+  exit 1
+fi
+KBN_DIR="$(pwd)"
+
+# --- Node / nvm setup ------------------------------------------------------
+# Source nvm and switch to the repo's .nvmrc version. Then pin the resolved
+# node binary at the front of PATH so backgrounded subshells can never fall
+# back to a system-installed node (e.g. Homebrew, volta, fnm).
+if [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  # shellcheck disable=SC1091
+  . "$NVM_DIR/nvm.sh"
+  nvm use
+  if [ -n "$NVM_BIN" ]; then
+    export PATH="$NVM_BIN:$PATH"
+  fi
+fi
+
+if ! command -v node >/dev/null 2>&1; then
+  echo "ERROR: node is not available. Install Node.js or nvm, then retry."
+  exit 1
+fi
+
+EXPECTED_NODE="v$(cat .nvmrc 2>/dev/null)"
+ACTUAL_NODE="$(node --version 2>/dev/null)"
+if [ "$EXPECTED_NODE" != "$ACTUAL_NODE" ]; then
+  echo "ERROR: Expected node $EXPECTED_NODE (from .nvmrc) but got $ACTUAL_NODE"
+  echo "  nvm may not have switched correctly. Try:"
+  echo "    nvm install $(cat .nvmrc)"
+  exit 1
+fi
+
+# --- Parse flags ------------------------------------------------------------
+CLEAN_CACHE=false
+SHOW_LOGS=true
+for arg in "$@"; do
+  case $arg in
+    --clean)        CLEAN_CACHE=true; shift ;;
+    --quiet) SHOW_LOGS=false; shift ;;
+    *) ;;
+  esac
+done
+
+# --- Chrome profile setup --------------------------------------------------
+LAUNCH_BROWSER=true
+CHROME_PROFILE_DIR="$HOME/.kbn-chrome"
+SLS_PROFILE="$CHROME_PROFILE_DIR/kbn-sls"
+STACK_PROFILE="$CHROME_PROFILE_DIR/kbn-stack"
+
+detect_chrome() {
+  local candidates=(
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
+    "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary"
+  )
+  for c in "${candidates[@]}"; do
+    [ -f "$c" ] && echo "$c" && return
+  done
+  for c in google-chrome google-chrome-stable chromium-browser chromium; do
+    command -v "$c" >/dev/null 2>&1 && command -v "$c" && return
+  done
+  return 1
+}
+
+if [ -n "$SKIP_BROWSER_LAUNCH" ]; then
+  [ "$INTERACTIVE" = true ] && echo "SKIP_BROWSER_LAUNCH is set — skipping Chrome setup."
+  LAUNCH_BROWSER=false
+elif [ -n "$CHROME_BIN" ]; then
+  CHROME_BIN_CLEAN="${CHROME_BIN//\\/}"
+  if [ "$CHROME_BIN_CLEAN" != "$CHROME_BIN" ] && [ -f "$CHROME_BIN_CLEAN" ]; then
+    echo "NOTE: Stripped backslashes from CHROME_BIN (use plain spaces inside double quotes)."
+    echo "  Was: $CHROME_BIN"
+    echo "  Now: $CHROME_BIN_CLEAN"
+    CHROME_BIN="$CHROME_BIN_CLEAN"
+  fi
+
+  if [ ! -f "$CHROME_BIN" ] && ! command -v "$CHROME_BIN" >/dev/null 2>&1; then
+    echo "WARNING: CHROME_BIN='$CHROME_BIN' was not found."
+    LAUNCH_BROWSER=false
+  fi
+else
+  if detected=$(detect_chrome); then
+    CHROME_BIN="$detected"
+    echo "Auto-detected Chrome: $CHROME_BIN"
+  else
+    [ "$INTERACTIVE" = true ] && echo "WARNING: Chrome was not found. Open Kibana URLs manually."
+    LAUNCH_BROWSER=false
+  fi
+fi
+
+if [ "$LAUNCH_BROWSER" = true ]; then
+  need_sls=false
+  need_stack=false
+  [ ! -d "$SLS_PROFILE" ] && need_sls=true
+  [ ! -d "$STACK_PROFILE" ] && need_stack=true
+
+  if [ "$need_sls" = true ] || [ "$need_stack" = true ]; then
+    if [ "$INTERACTIVE" = true ]; then
+      echo ""
+      echo "Chrome profiles needed for independent Kibana logins:"
+      [ "$need_sls" = true ]   && echo "  kbn-sls   (serverless)  -> $SLS_PROFILE   [not found]"
+      [ "$need_stack" = true ]  && echo "  kbn-stack (stateful)    -> $STACK_PROFILE  [not found]"
+      echo ""
+      read -r -p "  Create missing profile(s)? [Y/n] " answer
+    else
+      answer="y"
+    fi
+
+    case "$answer" in
+      [nN]*)
+        echo "  Skipping. Open Kibana manually at the URLs printed at the end."
+        LAUNCH_BROWSER=false
+        ;;
+      *)
+        profile_ok=true
+        for prof_dir in \
+          $([ "$need_sls" = true ] && echo "$SLS_PROFILE") \
+          $([ "$need_stack" = true ] && echo "$STACK_PROFILE"); do
+          if mkdir -p "$prof_dir" 2>/dev/null; then
+            echo "  Created: $prof_dir"
+          else
+            echo "  ERROR: Could not create $prof_dir"
+            profile_ok=false
+          fi
+        done
+        [ "$profile_ok" = false ] && LAUNCH_BROWSER=false
+        ;;
+    esac
+    echo ""
+  fi
+fi
+
+LAST_CHROME_PID=""
+open_chrome() {
+  local url="$1" profile="$2"
+  LAST_CHROME_PID=""
+  if [ "$LAUNCH_BROWSER" = true ]; then
+    log_step "Opening Chrome: $url (profile: $(basename "$profile"))"
+    if [[ "$OSTYPE" == darwin* ]]; then
+      open -na "Google Chrome" --args --new-window --user-data-dir="$profile" "$url" &
+    else
+      "$CHROME_BIN" --new-window --user-data-dir="$profile" "$url" 2>/dev/null &
+    fi
+    LAST_CHROME_PID=$!
+  fi
+}
+
+# --- Logging ----------------------------------------------------------------
+LOG_DIR="${KBN_LOG_DIR:-$HOME/.kbn/logs}"
+mkdir -p "$LOG_DIR"
+
+# --- Kill previous instance -------------------------------------------------
+PIDFILE="$LOG_DIR/kbn.pid"
+if [ -f "$PIDFILE" ]; then
+  OLD_PID=$(cat "$PIDFILE" 2>/dev/null)
+  if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then
+    echo "Stopping previous kbn-dev instance (PID $OLD_PID)..."
+    pkill -P "$OLD_PID" 2>/dev/null || true
+    kill "$OLD_PID" 2>/dev/null || true
+    sleep 2
+  fi
+fi
+echo $$ > "$PIDFILE"
+
+# --- PID tracking -----------------------------------------------------------
+OPTIMIZER_PID=""
+ESSLS_PID=""
+ESSTACK_PID=""
+KBNSLS_PID=""
+KBNSTACK_PID=""
+SLS_CHROME_PID=""
+STACK_CHROME_PID=""
+
+# --- Cleanup on exit --------------------------------------------------------
+cleanup() {
+  set +m 2>/dev/null
+  echo ""
+  echo "Stopping all processes..."
+
+  # Chrome
+  for profile_dir in "$SLS_PROFILE" "$STACK_PROFILE"; do
+    if [ -n "$profile_dir" ]; then
+      local chrome_pids
+      chrome_pids=$(pgrep -f "user-data-dir=$profile_dir" 2>/dev/null || true)
+      if [ -n "$chrome_pids" ]; then
+        echo "  Closing Chrome (profile: $(basename "$profile_dir"))"
+        echo "$chrome_pids" | xargs kill 2>/dev/null || true
+      fi
+    fi
+  done
+
+  # Kill Kibana node processes by port
+  for port in 5601 5611; do
+    local port_pid
+    port_pid=$(lsof -ti "tcp:$port" 2>/dev/null)
+    if [ -n "$port_pid" ]; then
+      echo "  Killing Kibana on port $port (PID $port_pid)"
+      kill "$port_pid" 2>/dev/null || true
+    fi
+  done
+
+  # Kill tracked PIDs and their children
+  for pid in $KBNSLS_PID $KBNSTACK_PID $OPTIMIZER_PID $ESSLS_PID $ESSTACK_PID; do
+    kill_tree "$pid"
+  done
+
+  sleep 2
+
+  # Force-kill anything still alive
+  for pid in $KBNSLS_PID $KBNSTACK_PID $OPTIMIZER_PID $ESSLS_PID $ESSTACK_PID; do
+    if [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null; then
+      echo "  Force-killing PID $pid"
+      pkill -9 -P "$pid" 2>/dev/null || true
+      kill -9 "$pid" 2>/dev/null || true
+    fi
+  done
+
+  # Kill any remaining node processes on Kibana ports
+  for port in 5601 5611; do
+    local port_pid
+    port_pid=$(lsof -ti "tcp:$port" 2>/dev/null)
+    if [ -n "$port_pid" ]; then
+      echo "  Force-killing orphan on port $port (PID $port_pid)"
+      kill -9 "$port_pid" 2>/dev/null || true
+    fi
+  done
+
+  # Stop ES Docker containers
+  if command -v docker >/dev/null 2>&1; then
+    local containers
+    containers=$(docker ps -q --filter "name=es01" --filter "name=es02" --filter "name=es03" --filter "name=uiam" --filter "name=uiam-cosmosdb" 2>/dev/null | xargs)
+    if [ -n "$containers" ]; then
+      echo "  Stopping Docker containers: $containers"
+      # shellcheck disable=SC2086
+      docker stop $containers 2>/dev/null || true
+      # shellcheck disable=SC2086
+      docker rm -f $containers 2>/dev/null || true
+    fi
+  fi
+
+  wait 2>/dev/null
+
+  if command -v tmux >/dev/null 2>&1 && tmux has-session -t kbn-logs 2>/dev/null; then
+    echo "  Killing tmux session 'kbn-logs'..."
+    tmux kill-session -t kbn-logs 2>/dev/null || true
+  fi
+
+  write_status "stopped"
+  rm -f "$PIDFILE" "$LOG_DIR/kbnsls.pid" "$LOG_DIR/kbnstack.pid"
+  echo "Cleanup complete."
+  exit
+}
+trap cleanup SIGINT SIGTERM
+
+# --- Log files --------------------------------------------------------------
+ESSLS_LOG="$LOG_DIR/essls.log"
+ESSTACK_LOG="$LOG_DIR/esstack.log"
+KBNSLS_LOG="$LOG_DIR/kbnsls.log"
+KBNSTACK_LOG="$LOG_DIR/kbnstack.log"
+OPTIMIZER_LOG="$LOG_DIR/optimizer.log"
+MAIN_LOG="$LOG_DIR/main.log"
+for f in "$ESSLS_LOG" "$ESSTACK_LOG" "$KBNSLS_LOG" "$KBNSTACK_LOG" "$OPTIMIZER_LOG" "$MAIN_LOG"; do
+  rm -f "$f"; touch "$f"
+done
+
+# --- Build inference flag ---------------------------------------------------
+KBN_INFERENCE_URL="${KBN_INFERENCE_URL:-https://inference.eu-west-1.aws.svc.qa.elastic.cloud}"
+INFERENCE_FLAG=""
+if [ -n "$KBN_INFERENCE_URL" ]; then
+  INFERENCE_FLAG="-E xpack.inference.elastic.url=$KBN_INFERENCE_URL"
+fi
+
+# --- Vault pre-check for EIS -----------------------------------------------
+EIS_VAULT_ADDR="${VAULT_ADDR:-https://secrets.elastic.co:8200}"
+EIS_VAULT_SECRET="secret/kibana-issues/dev/inference/kibana-eis-ccm"
+
+setup_eis_vault() {
+  if [ -z "$INFERENCE_FLAG" ]; then
+    return
+  fi
+
+  if [ -n "$KIBANA_EIS_CCM_API_KEY" ]; then
+    echo "  EIS enabled — using KIBANA_EIS_CCM_API_KEY (vault skipped)."
+    return
+  fi
+
+  echo ""
+  echo "============================================="
+  echo " EIS — Cloud Connected Mode"
+  echo "============================================="
+  echo ""
+  echo "  URL:     $KBN_INFERENCE_URL"
+  echo "  Vault:   $EIS_VAULT_ADDR"
+  echo "  Secret:  $EIS_VAULT_SECRET"
+  echo ""
+
+  if ! command -v vault >/dev/null 2>&1; then
+    echo "  ERROR: 'vault' CLI not found."
+    echo "  To fix: install vault, set KIBANA_EIS_CCM_API_KEY, or set KBN_INFERENCE_URL=\"\""
+    echo "  Continuing without EIS."
+    INFERENCE_FLAG=""
+    return
+  fi
+
+  while true; do
+    if VAULT_ADDR="$EIS_VAULT_ADDR" vault read -field key "$EIS_VAULT_SECRET" >/dev/null 2>&1; then
+      echo "  Vault access confirmed. EIS will run after each ES cluster is ready."
+      break
+    fi
+
+    if [ "$INTERACTIVE" = false ]; then
+      echo "  Vault access failed (non-interactive). Continuing without EIS."
+      INFERENCE_FLAG=""
+      return
+    fi
+
+    echo "  Vault access failed. Log in with:"
+    echo ""
+    echo "    VAULT_ADDR=$EIS_VAULT_ADDR vault login -method oidc"
+    echo ""
+    read -r -p "  Press Enter after logging in to retry (or Ctrl+C to abort)... "
+    echo ""
+  done
+  echo ""
+  echo "============================================="
+}
+
+setup_eis_vault
+
+# --- Print config summary ---------------------------------------------------
+open_tmux_logs() {
+  tmux kill-session -t kbn-logs 2>/dev/null || true
+  tmux new-session -d -s kbn-logs -n logs \
+    "tail -f $ESSLS_LOG" \; \
+    select-pane -T "ES Serverless" \; \
+    split-window -h \
+    "tail -f $ESSTACK_LOG" \; \
+    select-pane -T "ES Stateful" \; \
+    split-window -v \
+    "tail -f $KBNSTACK_LOG" \; \
+    select-pane -T "Kibana Stack" \; \
+    select-pane -t 0 \; \
+    split-window -v \
+    "tail -f $KBNSLS_LOG" \; \
+    select-pane -T "Kibana SLS" \; \
+    select-layout tiled \; \
+    set pane-border-status top \; \
+    set pane-border-format " #{pane_index}: #{pane_title} "
+}
+
+echo "============================================="
+echo " kbn-dev: Kibana dual-mode dev launcher"
+echo "============================================="
+echo "  Repo:      $KBN_DIR"
+echo "  Clean:     $CLEAN_CACHE"
+echo "  EIS:       $([ -n "$INFERENCE_FLAG" ] && echo "enabled ($KBN_INFERENCE_URL)" || echo "disabled")"
+echo "  Browser:   $([ "$LAUNCH_BROWSER" = true ] && echo "Chrome (kbn-sls + kbn-stack profiles)" || echo "disabled")"
+echo "  Show logs: $SHOW_LOGS"
+echo "============================================="
+echo ""
+echo " LOGGING"
+echo "  Dir: $LOG_DIR"
+echo "  Override with: KBN_LOG_DIR=/your/path"
+if [ "$SHOW_LOGS" = true ]; then
+  if command -v tmux >/dev/null 2>&1; then
+    echo "  Tmux log viewer will open automatically (--quiet to disable)."
+    echo "  Attach:  tmux attach -t kbn-logs"
+    echo "  Detach:  Ctrl+B then D"
+    echo "  Kill:    tmux kill-session -t kbn-logs"
+  else
+    echo "  WARNING: tmux not found. Install tmux for the log viewer."
+    echo "  Falling back to individual tail commands."
+    SHOW_LOGS=false
+  fi
+fi
+echo ""
+echo "============================================="
+
+if [ "$SHOW_LOGS" = true ]; then
+  open_tmux_logs
+  echo ""
+  echo "  tmux session 'kbn-logs' opened. Run 'yarn kbn-dev-ctl attach' to open it."
+  if command -v pbcopy >/dev/null 2>&1; then
+    echo "tmux attach -t kbn-logs" | pbcopy
+    echo "  Copied to clipboard: tmux attach -t kbn-logs  (⌘V in a new tab)"
+  elif command -v xclip >/dev/null 2>&1; then
+    echo "tmux attach -t kbn-logs" | xclip -selection clipboard
+    echo "  Copied to clipboard: tmux attach -t kbn-logs"
+  else
+    echo "  Attach with: tmux attach -t kbn-logs"
+  fi
+  echo ""
+fi
+
+write_status "starting"
+
+# =============================================================================
+# PHASE 1: Check ports + start Elasticsearch clusters in parallel
+# =============================================================================
+
+log_step "Cleaning up stale kibana-ci Docker resources..."
+if command -v docker >/dev/null 2>&1; then
+  stale_ids=$(docker ps -aq --filter "label=org.opencontainers.image.url=https://github.com/elastic/kibana" 2>/dev/null)
+  if [ -z "$stale_ids" ]; then
+    for img in uiam uiam-azure-cosmos-emulator elasticsearch-serverless; do
+      stale_ids="$stale_ids $(docker ps -aq --filter "ancestor=docker.elastic.co/kibana-ci/$img:latest-verified" 2>/dev/null)"
+    done
+  fi
+  stale_ids=$(echo "$stale_ids" | xargs)
+  if [ -n "$stale_ids" ]; then
+    echo "  Removing containers: $stale_ids"
+    # shellcheck disable=SC2086
+    docker rm -f $stale_ids 2>/dev/null || true
+  else
+    echo "  No stale containers."
+  fi
+
+  dangling=$(docker images -q --filter "dangling=true" --filter "reference=docker.elastic.co/kibana-ci/*" 2>/dev/null | xargs)
+  if [ -n "$dangling" ]; then
+    echo "  Removing dangling images: $dangling"
+    # shellcheck disable=SC2086
+    docker rmi $dangling 2>/dev/null || true
+  fi
+
+  if [ "$CLEAN_CACHE" = true ]; then
+    echo "  --clean: removing all kibana-ci images (will re-pull)..."
+    # shellcheck disable=SC2046
+    docker rmi $(docker images -q "docker.elastic.co/kibana-ci/*" 2>/dev/null) 2>/dev/null || true
+  fi
+else
+  echo "  Docker not available — skipping."
+fi
+
+log_step "Clearing dev ports..."
+for port in 9200 9201 9300 9301 5601 5611; do
+  pid=$(lsof -ti "tcp:$port" 2>/dev/null)
+  if [ -n "$pid" ]; then
+    proc_name=$(ps -p "$pid" -o comm= 2>/dev/null || echo "unknown")
+    echo "  Killing PID $pid on port $port ($proc_name)"
+    kill "$pid" 2>/dev/null || true
+  fi
+done
+
+if [ "$CLEAN_CACHE" = true ]; then
+  log_step "Cleaning ES cache (.es/cache)..."
+  rm -rf "$KBN_DIR/.es/cache/"
+fi
+
+log_step "Starting ES Serverless..." "$ESSLS_LOG"
+(
+  cd "$KBN_DIR" || exit 1
+  max_attempts=3
+  attempt=0
+  while [ $attempt -lt $max_attempts ]; do
+    attempt=$((attempt + 1))
+    # shellcheck disable=SC2086
+    yarn es serverless \
+      --projectType elasticsearch_general_purpose \
+      --clean --kill \
+      $INFERENCE_FLAG \
+    && break
+    echo ""
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts failed (uiam may need more time). Retrying..."
+    echo ""
+  done
+) >> "$ESSLS_LOG" 2>&1 &
+ESSLS_PID=$!
+
+log_step "Starting ES Stateful (snapshot)..." "$ESSTACK_LOG"
+(
+  cd "$KBN_DIR" || exit 1
+  # shellcheck disable=SC2086
+  yarn es snapshot \
+    --license trial --clean \
+    -E http.port=9201 \
+    -E transport.port=9301 \
+    -E xpack.ml.enabled=false \
+    $INFERENCE_FLAG
+) >> "$ESSTACK_LOG" 2>&1 &
+ESSTACK_PID=$!
+
+write_status "es_starting"
+
+# =============================================================================
+# PHASE 2: Bootstrap and build optimizer
+# =============================================================================
+
+(
+  cd "$KBN_DIR" || exit 1
+  if [ "$CLEAN_CACHE" = true ]; then
+    log_step "Running yarn kbn clean..." "$MAIN_LOG"
+    yarn kbn clean || exit 1
+  fi
+  log_step "Running yarn kbn bootstrap..." "$MAIN_LOG"
+  yarn kbn bootstrap || exit 1
+) >> "$MAIN_LOG" 2>&1
+BOOTSTRAP_EXIT=$?
+
+if [ $BOOTSTRAP_EXIT -ne 0 ]; then
+  log_step "ERROR: Bootstrap failed (exit $BOOTSTRAP_EXIT). Check $MAIN_LOG"
+  echo "  Tip: run 'yarn kbn bootstrap' manually to see the full error."
+  cleanup
+fi
+
+log_step "Starting optimizer (watch mode)..."
+(
+  cd "$KBN_DIR" || exit 1
+  node scripts/build_kibana_platform_plugins --watch
+) >> "$OPTIMIZER_LOG" 2>&1 &
+OPTIMIZER_PID=$!
+
+log_step "Waiting for optimizer initial build..."
+if wait_for_log "$OPTIMIZER_LOG" "succ.*bundles compiled successfully\|succ all bundles cached" "$OPTIMIZER_PID" "Optimizer"; then
+  log_step "Optimizer build complete!"
+fi
+
+write_status "optimizer_ready"
+
+# =============================================================================
+# PHASE 3: Wait for ES → run EIS → start Kibana
+# =============================================================================
+
+start_kbnsls() {
+  kill_port 5601
+  log_step "Starting Kibana Serverless (port 5601)..." "$KBNSLS_LOG"
+  (
+    cd "$KBN_DIR" || exit 1
+    export KBN_OPTIMIZER_USE_MAX_AVAILABLE_RESOURCES=false
+    yarn serverless-es \
+      --server.port=5601 \
+      --no-optimizer
+  ) >> "$KBNSLS_LOG" 2>&1
+}
+
+start_kbnstack() {
+  kill_port 5611
+  log_step "Starting Kibana Stateful (port 5611)..." "$KBNSTACK_LOG"
+  (
+    cd "$KBN_DIR" || exit 1
+    export KBN_OPTIMIZER_USE_MAX_AVAILABLE_RESOURCES=false
+    yarn start \
+      --elasticsearch http://localhost:9201 \
+      --server.port=5611 \
+      --xpack.security.cookieName=sid-stack \
+      --no-optimizer
+  ) >> "$KBNSTACK_LOG" 2>&1
+}
+
+monitor_process() {
+  local name="$1" start_fn="$2" logfile="$3"
+  local failures=0 max_failures=3
+
+  while true; do
+    $start_fn &
+    local pid=$!
+    wait $pid
+    local exit_code=$?
+
+    if [ $exit_code -eq 130 ] || [ $exit_code -eq 143 ]; then
+      break
+    elif [ $exit_code -ne 0 ]; then
+      failures=$((failures + 1))
+      log_step "$name exited with code $exit_code (attempt $failures/$max_failures)" "$logfile"
+      if [ $failures -lt $max_failures ]; then
+        log_step "Restarting $name in 5s..."
+        sleep 5
+      else
+        log_step "$name exceeded max retries ($max_failures). Giving up."
+        kill $$ 2>/dev/null
+        exit 1
+      fi
+    else
+      log_step "$name exited cleanly (code 0)"
+      break
+    fi
+  done
+}
+
+run_es_to_kibana_pipeline() {
+  local es_label="$1" es_log="$2" es_pid="$3" es_ready_pattern="$4"
+  local kbn_label="$5" kbn_start_fn="$6" kbn_log="$7" kbn_pidfile="$8"
+
+  log_step "Waiting for $es_label to be ready..."
+  if ! wait_for_log "$es_log" "$es_ready_pattern" "$es_pid" "$es_label"; then
+    return 1
+  fi
+
+  log_step "$es_label is ready!"
+
+  if [ -n "$INFERENCE_FLAG" ]; then
+    log_step "Running EIS setup for $es_label (node scripts/eis.js)..."
+    (cd "$KBN_DIR" && node scripts/eis.js) >> "$MAIN_LOG" 2>&1
+  fi
+
+  monitor_process "$kbn_label" "$kbn_start_fn" "$kbn_log" &
+  echo "$!" > "$kbn_pidfile"
+  wait
+}
+
+# Serverless pipeline (background)
+(
+  run_es_to_kibana_pipeline \
+    "ES Serverless" "$ESSLS_LOG" "$ESSLS_PID" "succ Serverless ES cluster running" \
+    "kbnsls" start_kbnsls "$KBNSLS_LOG" "$LOG_DIR/kbnsls.pid"
+) &
+
+# Stateful pipeline (background)
+(
+  run_es_to_kibana_pipeline \
+    "ES Stateful" "$ESSTACK_LOG" "$ESSTACK_PID" "succ ES cluster is ready" \
+    "kbnstack" start_kbnstack "$KBNSTACK_LOG" "$LOG_DIR/kbnstack.pid"
+) &
+
+# =============================================================================
+# PHASE 4: Wait for Kibana → open browser → report
+# =============================================================================
+
+SLS_READY=false
+STACK_READY=false
+SLS_WAIT_DONE=false
+STACK_WAIT_DONE=false
+
+# Wait for both in parallel using background subshells and marker files
+SLS_MARKER="$LOG_DIR/.sls_ready"
+STACK_MARKER="$LOG_DIR/.stack_ready"
+rm -f "$SLS_MARKER" "$STACK_MARKER"
+
+(
+  if wait_for_kibana "Kibana Serverless" "$KBNSLS_LOG" "$ESSLS_PID" "$LOG_DIR/kbnsls.pid" 5601; then
+    touch "$SLS_MARKER"
+  fi
+) &
+SLS_WAIT_PID=$!
+
+(
+  if wait_for_kibana "Kibana Stateful" "$KBNSTACK_LOG" "$ESSTACK_PID" "$LOG_DIR/kbnstack.pid" 5611; then
+    touch "$STACK_MARKER"
+  fi
+) &
+STACK_WAIT_PID=$!
+
+# Wait for both to finish
+wait $SLS_WAIT_PID 2>/dev/null
+wait $STACK_WAIT_PID 2>/dev/null
+
+if [ -f "$SLS_MARKER" ]; then
+  log_step "Kibana Serverless is available at http://localhost:5601"
+  SLS_READY=true
+  open_chrome "http://localhost:5601" "$SLS_PROFILE"
+  SLS_CHROME_PID="$LAST_CHROME_PID"
+fi
+
+if [ -f "$STACK_MARKER" ]; then
+  log_step "Kibana Stateful is available at http://localhost:5611"
+  STACK_READY=true
+  open_chrome "http://localhost:5611" "$STACK_PROFILE"
+  STACK_CHROME_PID="$LAST_CHROME_PID"
+fi
+
+rm -f "$SLS_MARKER" "$STACK_MARKER"
+
+# --- Read child PIDs --------------------------------------------------------
+[ -f "$LOG_DIR/kbnsls.pid" ]  && KBNSLS_PID=$(cat "$LOG_DIR/kbnsls.pid")
+[ -f "$LOG_DIR/kbnstack.pid" ] && KBNSTACK_PID=$(cat "$LOG_DIR/kbnstack.pid")
+
+# --- Status report ----------------------------------------------------------
+if [ "$SLS_READY" = false ] && [ "$STACK_READY" = false ]; then
+  write_status "failed"
+  echo ""
+  echo "============================================="
+  echo " STARTUP FAILED"
+  echo "============================================="
+  echo ""
+  echo "  Neither Kibana instance came up. Check the logs:"
+  echo "    yarn kbn-dev-ctl logs essls --grep ERROR"
+  echo "    yarn kbn-dev-ctl logs esstack --grep ERROR"
+  echo ""
+  echo "  Common causes: Docker not running, bootstrap needed (--clean), node mismatch."
+  echo ""
+  cleanup
+fi
+
+if [ "$SLS_READY" = false ] || [ "$STACK_READY" = false ]; then
+  echo ""
+  [ "$SLS_READY" = false ]  && echo "  WARNING: Kibana Serverless failed to start. Check: yarn kbn-dev-ctl logs essls --grep ERROR"
+  [ "$STACK_READY" = false ] && echo "  WARNING: Kibana Stateful failed to start. Check: yarn kbn-dev-ctl logs esstack --grep ERROR"
+  echo "  Continuing with available instance(s)."
+  echo ""
+fi
+
+write_status "running"
+
+echo ""
+echo "============================================="
+echo " STATUS"
+echo "============================================="
+echo ""
+[ "$SLS_READY" = true ]   && echo "  [OK]     Kibana Serverless:  http://localhost:5601" \
+                           || echo "  [FAILED] Kibana Serverless — check $KBNSLS_LOG"
+[ "$STACK_READY" = true ]  && echo "  [OK]     Kibana Stateful:    http://localhost:5611" \
+                           || echo "  [FAILED] Kibana Stateful — check $KBNSTACK_LOG"
+echo ""
+echo "  PIDs:"
+echo "    Optimizer:        $OPTIMIZER_PID"
+echo "    ES Serverless:    $ESSLS_PID"
+echo "    ES Stateful:      $ESSTACK_PID"
+echo "    Kibana SLS:       ${KBNSLS_PID:-(not started)}"
+echo "    Kibana Stack:     ${KBNSTACK_PID:-(not started)}"
+[ -n "$SLS_CHROME_PID" ]   && echo "    Chrome SLS:       $SLS_CHROME_PID"
+[ -n "$STACK_CHROME_PID" ] && echo "    Chrome Stack:     $STACK_CHROME_PID"
+echo ""
+echo "  Logs: $LOG_DIR"
+if [ "$SHOW_LOGS" = true ]; then
+  echo "  View: tmux attach -t kbn-logs"
+else
+  echo "  View: tail -f $LOG_DIR/*.log"
+fi
+echo ""
+echo "============================================="
+echo "Press Ctrl+C to stop all processes."
+
+wait

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -39,12 +39,14 @@
 # Interactive prompts auto-accept and verbose banners are suppressed.
 INTERACTIVE=true
 [ -t 0 ] || INTERACTIVE=false
+SHUTTING_DOWN=false
 
 # =============================================================================
 # Utility functions
 # =============================================================================
 
 log_step() {
+  [ "$SHUTTING_DOWN" = true ] && return
   local msg="$1"
   local logfile="${2:-}"
   local line
@@ -367,6 +369,7 @@ STACK_CHROME_PID=""
 
 # --- Cleanup on exit --------------------------------------------------------
 cleanup() {
+  SHUTTING_DOWN=true
   set +m 2>/dev/null
   echo ""
   echo "Stopping all processes..."

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -640,26 +640,58 @@ log_step "Starting ES Serverless..." "$ESSLS_LOG"
 (
   cd "$KBN_DIR" || exit 1
 
-  # uiam crashes if cosmosdb isn't ready (zero retries in the Cosmos DB
-  # client). yarn es serverless's cleanup kills all containers on failure.
-  # Simple retry: Docker images are cached after attempt 1, so cosmosdb
-  # starts faster on subsequent attempts, closing the race window.
-  max_attempts=3
-  attempt=0
-  while [ $attempt -lt $max_attempts ]; do
-    attempt=$((attempt + 1))
-    [ $attempt -gt 1 ] && echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts (Docker images cached, cosmosdb starts faster)..."
+  # uiam crashes if cosmosdb isn't ready (zero retries in its Cosmos DB
+  # client, exits immediately on 503). yarn es serverless kills all
+  # containers on failure. Retries use --no-uiam on the first pass to let
+  # ES + cosmosdb start without uiam, then a second yarn es adds uiam
+  # once cosmosdb is healthy.
+  # shellcheck disable=SC2086
+  yarn es serverless \
+    --projectType elasticsearch_general_purpose \
+    --clean --kill \
+    $INFERENCE_FLAG
+  es_exit=$?
 
+  if [ $es_exit -ne 0 ]; then
+    echo ""
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless failed (uiam/cosmosdb race). Retrying with cosmosdb pre-warm..."
+
+    # Start just cosmosdb manually and wait for it to be healthy
+    docker rm -f uiam uiam-cosmosdb es01 es02 es03 2>/dev/null || true
+    docker network create elastic 2>/dev/null || true
+
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting cosmosdb emulator..."
+    docker run -d \
+      --name uiam-cosmosdb \
+      --net elastic \
+      --health-cmd 'curl -sk http://127.0.0.1:8080/ready | grep -q "\"overall\": true"' \
+      --health-interval 5s --health-timeout 2s --health-retries 30 --health-start-period 3s \
+      -p "127.0.0.1:8087:8081" \
+      docker.elastic.co/kibana-ci/uiam-azure-cosmos-emulator:latest-verified \
+      --protocol https --port 8081 2>/dev/null || true
+
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Waiting for cosmosdb to become healthy..."
+    local tries=0
+    while [ $tries -lt 40 ]; do
+      local cdb_status
+      cdb_status=$(docker inspect -f '{{.State.Health.Status}}' uiam-cosmosdb 2>/dev/null || echo "missing")
+      if [ "$cdb_status" = "healthy" ]; then
+        echo "[$(date '+%Y-%m-%d %H:%M:%S')] cosmosdb is healthy. Starting ES Serverless..."
+        break
+      fi
+      tries=$((tries + 1))
+      sleep 3
+    done
+
+    # Now run yarn es serverless — cosmosdb is already running and healthy,
+    # so when yarn starts uiam, it can connect immediately.
+    # Don't use --clean (it would kill our healthy cosmosdb).
     # shellcheck disable=SC2086
     yarn es serverless \
       --projectType elasticsearch_general_purpose \
-      --clean --kill \
-      $INFERENCE_FLAG \
-    && break
-
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts failed (uiam/cosmosdb race condition)."
-    sleep 3
-  done
+      --kill \
+      $INFERENCE_FLAG
+  fi
 ) >> "$ESSLS_LOG" 2>&1 &
 ESSLS_PID=$!
 

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -879,8 +879,16 @@ fi
 
 if [ "$SLS_READY" = false ] || [ "$STACK_READY" = false ]; then
   echo ""
-  [ "$SLS_READY" = false ]  && echo "  WARNING: Kibana Serverless failed to start. Check: yarn kbn-dev-ctl logs essls --grep ERROR"
-  [ "$STACK_READY" = false ] && echo "  WARNING: Kibana Stateful failed to start. Check: yarn kbn-dev-ctl logs esstack --grep ERROR"
+  if [ "$SLS_READY" = false ]; then
+    echo "  WARNING: Kibana Serverless failed to start."
+    echo "    Check: yarn kbn-dev-ctl logs essls --grep ERROR"
+    echo "    Common fix: the uiam Docker container needs more time/memory."
+    echo "    Try increasing Docker memory to 24GB+ in OrbStack/Docker Desktop settings."
+  fi
+  if [ "$STACK_READY" = false ]; then
+    echo "  WARNING: Kibana Stateful failed to start."
+    echo "    Check: yarn kbn-dev-ctl logs esstack --grep ERROR"
+  fi
   echo "  Continuing with available instance(s)."
   echo ""
 fi

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -612,6 +612,10 @@ if command -v docker >/dev/null 2>&1; then
     docker rmi $dangling 2>/dev/null || true
   fi
 
+  # Remove stale 'elastic' Docker network — stale DNS entries from crashed
+  # containers can cause uiam to fail resolving uiam-cosmosdb.
+  docker network rm elastic 2>/dev/null || true
+
   if [ "$CLEAN_CACHE" = true ]; then
     echo "  --clean: removing all kibana-ci images (will re-pull)..."
     # shellcheck disable=SC2046

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -644,9 +644,8 @@ log_step "Starting ES Serverless..." "$ESSLS_LOG"
 (
   cd "$KBN_DIR" || exit 1
 
-  # uiam can crash if cosmosdb isn't ready yet (upstream bug: zero retries
-  # in the Cosmos DB client). Retry up to 3 times — each attempt is a
-  # full clean start via yarn es serverless.
+  # Retry up to 3 times in case of uiam/cosmosdb startup race.
+  # The Docker network cleanup before this step usually prevents the issue.
   max_attempts=3
   attempt=0
   while [ $attempt -lt $max_attempts ]; do

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -576,16 +576,9 @@ echo "============================================="
 if [ "$SHOW_LOGS" = true ]; then
   open_tmux_logs
   echo ""
-  echo "  tmux session 'kbn-logs' opened. Run 'yarn kbn-dev-ctl attach' to open it."
-  if command -v pbcopy >/dev/null 2>&1; then
-    echo "tmux attach -t kbn-logs" | pbcopy
-    echo "  Copied to clipboard: tmux attach -t kbn-logs  (⌘V in a new tab)"
-  elif command -v xclip >/dev/null 2>&1; then
-    echo "tmux attach -t kbn-logs" | xclip -selection clipboard
-    echo "  Copied to clipboard: tmux attach -t kbn-logs"
-  else
-    echo "  Attach with: tmux attach -t kbn-logs"
-  fi
+  echo "  tmux session 'kbn-logs' opened. Attach in another terminal:"
+  echo ""
+  echo "    tmux attach -t kbn-logs"
   echo ""
 fi
 

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -640,58 +640,25 @@ log_step "Starting ES Serverless..." "$ESSLS_LOG"
 (
   cd "$KBN_DIR" || exit 1
 
-  # uiam crashes if cosmosdb isn't ready (zero retries in its Cosmos DB
-  # client, exits immediately on 503). yarn es serverless kills all
-  # containers on failure. Retries use --no-uiam on the first pass to let
-  # ES + cosmosdb start without uiam, then a second yarn es adds uiam
-  # once cosmosdb is healthy.
-  # shellcheck disable=SC2086
-  yarn es serverless \
-    --projectType elasticsearch_general_purpose \
-    --clean --kill \
-    $INFERENCE_FLAG
-  es_exit=$?
+  # uiam can crash if cosmosdb isn't ready yet (upstream bug: zero retries
+  # in the Cosmos DB client). Retry up to 3 times — each attempt is a
+  # full clean start via yarn es serverless.
+  max_attempts=3
+  attempt=0
+  while [ $attempt -lt $max_attempts ]; do
+    attempt=$((attempt + 1))
+    [ $attempt -gt 1 ] && echo "" && echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts..."
 
-  if [ $es_exit -ne 0 ]; then
-    echo ""
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless failed (uiam/cosmosdb race). Retrying with cosmosdb pre-warm..."
-
-    # Start just cosmosdb manually and wait for it to be healthy
-    docker rm -f uiam uiam-cosmosdb es01 es02 es03 2>/dev/null || true
-    docker network create elastic 2>/dev/null || true
-
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting cosmosdb emulator..."
-    docker run -d \
-      --name uiam-cosmosdb \
-      --net elastic \
-      --health-cmd 'curl -sk http://127.0.0.1:8080/ready | grep -q "\"overall\": true"' \
-      --health-interval 5s --health-timeout 2s --health-retries 30 --health-start-period 3s \
-      -p "127.0.0.1:8087:8081" \
-      docker.elastic.co/kibana-ci/uiam-azure-cosmos-emulator:latest-verified \
-      --protocol https --port 8081 2>/dev/null || true
-
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Waiting for cosmosdb to become healthy..."
-    local tries=0
-    while [ $tries -lt 40 ]; do
-      local cdb_status
-      cdb_status=$(docker inspect -f '{{.State.Health.Status}}' uiam-cosmosdb 2>/dev/null || echo "missing")
-      if [ "$cdb_status" = "healthy" ]; then
-        echo "[$(date '+%Y-%m-%d %H:%M:%S')] cosmosdb is healthy. Starting ES Serverless..."
-        break
-      fi
-      tries=$((tries + 1))
-      sleep 3
-    done
-
-    # Now run yarn es serverless — cosmosdb is already running and healthy,
-    # so when yarn starts uiam, it can connect immediately.
-    # Don't use --clean (it would kill our healthy cosmosdb).
     # shellcheck disable=SC2086
     yarn es serverless \
       --projectType elasticsearch_general_purpose \
-      --kill \
-      $INFERENCE_FLAG
-  fi
+      --clean --kill \
+      $INFERENCE_FLAG \
+    && break
+
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts failed (uiam/cosmosdb startup race)."
+    sleep 5
+  done
 ) >> "$ESSLS_LOG" 2>&1 &
 ESSLS_PID=$!
 

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -640,50 +640,26 @@ log_step "Starting ES Serverless..." "$ESSLS_LOG"
 (
   cd "$KBN_DIR" || exit 1
 
-  # Pre-warm: if cosmosdb is already running and healthy, skip the wait.
-  # Otherwise, yarn es serverless will start it, and we wait for it to be
-  # healthy before uiam tries to connect (uiam has zero retries and crashes
-  # if cosmosdb isn't ready).
-  wait_for_cosmosdb() {
-    local cosmosdb_status
-    cosmosdb_status=$(docker inspect -f '{{.State.Health.Status}}' uiam-cosmosdb 2>/dev/null || echo "missing")
-    if [ "$cosmosdb_status" = "healthy" ]; then
-      echo "[$(date '+%Y-%m-%d %H:%M:%S')] cosmosdb already healthy"
-      return 0
-    fi
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Waiting for cosmosdb to become healthy..."
-    local tries=0
-    while [ $tries -lt 60 ]; do
-      cosmosdb_status=$(docker inspect -f '{{.State.Health.Status}}' uiam-cosmosdb 2>/dev/null || echo "missing")
-      [ "$cosmosdb_status" = "healthy" ] && echo "[$(date '+%Y-%m-%d %H:%M:%S')] cosmosdb is healthy" && return 0
-      tries=$((tries + 1))
-      sleep 2
-    done
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] cosmosdb did not become healthy in time"
-    return 1
-  }
+  # uiam crashes if cosmosdb isn't ready (zero retries in the Cosmos DB
+  # client). yarn es serverless's cleanup kills all containers on failure.
+  # Simple retry: Docker images are cached after attempt 1, so cosmosdb
+  # starts faster on subsequent attempts, closing the race window.
+  max_attempts=3
+  attempt=0
+  while [ $attempt -lt $max_attempts ]; do
+    attempt=$((attempt + 1))
+    [ $attempt -gt 1 ] && echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts (Docker images cached, cosmosdb starts faster)..."
 
-  # shellcheck disable=SC2086
-  yarn es serverless \
-    --projectType elasticsearch_general_purpose \
-    --clean --kill \
-    $INFERENCE_FLAG
-  es_exit=$?
-
-  # If the first attempt failed (uiam crashed because cosmosdb wasn't ready),
-  # cosmosdb and ES nodes may still be running. Wait for cosmosdb to be
-  # healthy, remove just the crashed uiam, and retry without --clean --kill
-  # so the healthy containers are preserved.
-  if [ $es_exit -ne 0 ]; then
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless failed (exit $es_exit). Checking cosmosdb..."
-    wait_for_cosmosdb
-    docker rm -f uiam 2>/dev/null || true
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Retrying ES Serverless (preserving healthy containers)..."
     # shellcheck disable=SC2086
     yarn es serverless \
       --projectType elasticsearch_general_purpose \
-      $INFERENCE_FLAG
-  fi
+      --clean --kill \
+      $INFERENCE_FLAG \
+    && break
+
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts failed (uiam/cosmosdb race condition)."
+    sleep 3
+  done
 ) >> "$ESSLS_LOG" 2>&1 &
 ESSLS_PID=$!
 

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -646,32 +646,55 @@ fi
 log_step "Starting ES Serverless..." "$ESSLS_LOG"
 (
   cd "$KBN_DIR" || exit 1
-  max_attempts=3
-  attempt=0
-  while [ $attempt -lt $max_attempts ]; do
-    attempt=$((attempt + 1))
-    if [ $attempt -eq 1 ]; then
-      # First attempt: clean start
-      # shellcheck disable=SC2086
-      yarn es serverless \
-        --projectType elasticsearch_general_purpose \
-        --clean --kill \
-        $INFERENCE_FLAG \
-      && break
-    else
-      # Retries: don't use --clean --kill so cosmosdb (which may already
-      # be healthy) stays up. Only remove the crashed uiam container.
-      docker rm -f uiam 2>/dev/null || true
-      # shellcheck disable=SC2086
-      yarn es serverless \
-        --projectType elasticsearch_general_purpose \
-        $INFERENCE_FLAG \
-      && break
+
+  # Pre-warm: if cosmosdb is already running and healthy, skip the wait.
+  # Otherwise, yarn es serverless will start it, and we wait for it to be
+  # healthy before uiam tries to connect (uiam has zero retries and crashes
+  # if cosmosdb isn't ready).
+  wait_for_cosmosdb() {
+    local cosmosdb_status
+    cosmosdb_status=$(docker inspect -f '{{.State.Health.Status}}' uiam-cosmosdb 2>/dev/null || echo "missing")
+    if [ "$cosmosdb_status" = "healthy" ]; then
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] cosmosdb already healthy"
+      return 0
     fi
-    echo ""
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts failed (uiam may need more time). Retrying..."
-    echo ""
-  done
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] Waiting for cosmosdb to become healthy..."
+    local tries=0
+    while [ $tries -lt 60 ]; do
+      cosmosdb_status=$(docker inspect -f '{{.State.Health.Status}}' uiam-cosmosdb 2>/dev/null || echo "missing")
+      [ "$cosmosdb_status" = "healthy" ] && echo "[$(date '+%Y-%m-%d %H:%M:%S')] cosmosdb is healthy" && return 0
+      tries=$((tries + 1))
+      sleep 2
+    done
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] cosmosdb did not become healthy in time"
+    return 1
+  }
+
+  # shellcheck disable=SC2086
+  yarn es serverless \
+    --projectType elasticsearch_general_purpose \
+    --clean --kill \
+    $INFERENCE_FLAG &
+  ES_SLS_PID=$!
+
+  # Wait for cosmosdb to become healthy, then let yarn es continue
+  sleep 5
+  wait_for_cosmosdb
+
+  # If uiam crashed because cosmosdb wasn't ready, restart just uiam
+  if ! docker inspect -f '{{.State.Running}}' uiam 2>/dev/null | grep -q true; then
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] uiam is not running — restarting it"
+    docker rm -f uiam 2>/dev/null || true
+    # Trigger yarn es to restart uiam by killing and re-running
+    kill $ES_SLS_PID 2>/dev/null || true
+    wait $ES_SLS_PID 2>/dev/null || true
+    # shellcheck disable=SC2086
+    yarn es serverless \
+      --projectType elasticsearch_general_purpose \
+      $INFERENCE_FLAG
+  else
+    wait $ES_SLS_PID
+  fi
 ) >> "$ESSLS_LOG" 2>&1 &
 ESSLS_PID=$!
 
@@ -894,8 +917,6 @@ if [ "$SLS_READY" = false ] || [ "$STACK_READY" = false ]; then
   if [ "$SLS_READY" = false ]; then
     echo "  WARNING: Kibana Serverless failed to start."
     echo "    Check: yarn kbn-dev-ctl logs essls --grep ERROR"
-    echo "    Common fix: the uiam Docker container needs more time/memory."
-    echo "    Try increasing Docker memory to 24GB+ in OrbStack/Docker Desktop settings."
   fi
   if [ "$STACK_READY" = false ]; then
     echo "  WARNING: Kibana Stateful failed to start."

--- a/scripts/kbn_dev.sh
+++ b/scripts/kbn_dev.sh
@@ -650,12 +650,24 @@ log_step "Starting ES Serverless..." "$ESSLS_LOG"
   attempt=0
   while [ $attempt -lt $max_attempts ]; do
     attempt=$((attempt + 1))
-    # shellcheck disable=SC2086
-    yarn es serverless \
-      --projectType elasticsearch_general_purpose \
-      --clean --kill \
-      $INFERENCE_FLAG \
-    && break
+    if [ $attempt -eq 1 ]; then
+      # First attempt: clean start
+      # shellcheck disable=SC2086
+      yarn es serverless \
+        --projectType elasticsearch_general_purpose \
+        --clean --kill \
+        $INFERENCE_FLAG \
+      && break
+    else
+      # Retries: don't use --clean --kill so cosmosdb (which may already
+      # be healthy) stays up. Only remove the crashed uiam container.
+      docker rm -f uiam 2>/dev/null || true
+      # shellcheck disable=SC2086
+      yarn es serverless \
+        --projectType elasticsearch_general_purpose \
+        $INFERENCE_FLAG \
+      && break
+    fi
     echo ""
     echo "[$(date '+%Y-%m-%d %H:%M:%S')] ES Serverless attempt $attempt/$max_attempts failed (uiam may need more time). Retrying..."
     echo ""

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -255,12 +255,12 @@ cmd_restart() {
   es_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$es_port" 2>/dev/null || echo "000")
   if [ "$es_code" = "000" ]; then
     echo ""
-    echo "  WARNING: ES on port $es_port is not responding."
-    echo "  Kibana will not start without ES. You may need a full restart:"
+    echo "  ERROR: ES on port $es_port is not responding."
+    echo "  Kibana cannot start without ES. A full restart is needed:"
     echo "    yarn kbn-dev-ctl stop && yarn kbn-dev"
-  else
-    echo "  The monitor_process loop in kbn-dev will auto-restart $comp."
+    exit 1
   fi
+  echo "  The monitor_process loop will auto-restart $comp."
   echo "  Watch the logs: tail -f $(component_log "$comp")"
 }
 

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+# kbn-dev-ctl — query and control a kbn-dev instance
+#
+# Usage:
+#   yarn kbn-dev-ctl status [--json]            Show component health
+#   yarn kbn-dev-ctl logs <component>           Tail the last 50 lines of a component log
+#     [--tail N]                         Number of lines (default 50)
+#     [--follow]                         Follow (tail -f)
+#     [--grep PATTERN]                   Filter lines
+#   yarn kbn-dev-ctl restart <component>        Restart kbnsls or kbnstack
+#   yarn kbn-dev-ctl stop                       Stop the entire kbn-dev instance
+#
+# Components: essls, esstack, optimizer, kbnsls, kbnstack, all
+#
+# The log directory defaults to ~/.kbn/logs (override with KBN_LOG_DIR).
+# All commands work from any directory.
+# ---------------------------------------------------------------------------
+
+set -euo pipefail
+
+# --- Locate log directory ---------------------------------------------------
+find_log_dir() {
+  local d="${KBN_LOG_DIR:-$HOME/.kbn/logs}"
+  mkdir -p "$d" 2>/dev/null
+  echo "$d"
+}
+
+LOG_DIR="$(find_log_dir)"
+STATUS_FILE="$LOG_DIR/status.json"
+
+# --- Helpers ----------------------------------------------------------------
+component_log() {
+  local comp="$1"
+  case "$comp" in
+    essls)     echo "$LOG_DIR/essls.log" ;;
+    esstack)   echo "$LOG_DIR/esstack.log" ;;
+    optimizer) echo "$LOG_DIR/optimizer.log" ;;
+    kbnsls)    echo "$LOG_DIR/kbnsls.log" ;;
+    kbnstack)  echo "$LOG_DIR/kbnstack.log" ;;
+    main)      echo "$LOG_DIR/main.log" ;;
+    *)         echo "ERROR: Unknown component '$comp'" >&2
+               echo "  Valid: essls, esstack, optimizer, kbnsls, kbnstack, main" >&2
+               exit 1 ;;
+  esac
+}
+
+pid_alive() {
+  local pid="$1"
+  [ -n "$pid" ] && [ "$pid" != "null" ] && kill -0 "$pid" 2>/dev/null
+}
+
+port_listening() {
+  local port="$1"
+  lsof -ti "tcp:$port" >/dev/null 2>&1
+}
+
+check_ready() {
+  local logfile="$1" pattern="$2"
+  grep -q "$pattern" "$logfile" 2>/dev/null
+}
+
+# --- status -----------------------------------------------------------------
+cmd_status() {
+  local json_mode=false
+  [ "${1:-}" = "--json" ] && json_mode=true
+
+  local main_pid=""
+  [ -f "$LOG_DIR/kbn.pid" ] && main_pid=$(cat "$LOG_DIR/kbn.pid" 2>/dev/null)
+  local main_alive=false
+  pid_alive "$main_pid" && main_alive=true
+
+  local state="unknown"
+  [ -f "$STATUS_FILE" ] && state=$(grep -o '"state": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | head -1 | sed 's/.*: *"//;s/"//')
+
+  local essls_pid="" esstack_pid="" optimizer_pid="" kbnsls_pid="" kbnstack_pid=""
+  if [ -f "$STATUS_FILE" ]; then
+    essls_pid=$(grep -o '"essls".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
+    esstack_pid=$(grep -o '"esstack".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
+    optimizer_pid=$(grep -o '"optimizer".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
+    kbnsls_pid=$(grep -o '"kbnsls".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
+    kbnstack_pid=$(grep -o '"kbnstack".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
+  fi
+
+  local essls_alive=false esstack_alive=false optimizer_alive=false
+  local kbnsls_alive=false kbnstack_alive=false
+  pid_alive "$essls_pid" && essls_alive=true
+  pid_alive "$esstack_pid" && esstack_alive=true
+  pid_alive "$optimizer_pid" && optimizer_alive=true
+  pid_alive "$kbnsls_pid" && kbnsls_alive=true
+  pid_alive "$kbnstack_pid" && kbnstack_alive=true
+
+  local p5601=false p5611=false p9200=false p9201=false
+  port_listening 5601 && p5601=true
+  port_listening 5611 && p5611=true
+  port_listening 9200 && p9200=true
+  port_listening 9201 && p9201=true
+
+  local essls_ready=false esstack_ready=false kbnsls_ready=false kbnstack_ready=false
+  if [ "$essls_alive" = true ] || [ "$p9200" = true ]; then
+    check_ready "$LOG_DIR/essls.log" "succ Serverless ES cluster running" && essls_ready=true
+  fi
+  if [ "$esstack_alive" = true ] || [ "$p9201" = true ]; then
+    check_ready "$LOG_DIR/esstack.log" "succ ES cluster is ready" && esstack_ready=true
+  fi
+  if [ "$kbnsls_alive" = true ] || [ "$p5601" = true ]; then
+    check_ready "$LOG_DIR/kbnsls.log" "\[INFO \]\[status\] Kibana is now available" && kbnsls_ready=true
+  fi
+  if [ "$kbnstack_alive" = true ] || [ "$p5611" = true ]; then
+    check_ready "$LOG_DIR/kbnstack.log" "\[INFO \]\[status\] Kibana is now available" && kbnstack_ready=true
+  fi
+
+  if [ "$json_mode" = true ]; then
+    cat <<EOF
+{
+  "running": $main_alive,
+  "state": "$state",
+  "pid": ${main_pid:-null},
+  "log_dir": "$LOG_DIR",
+  "components": {
+    "essls":     { "pid": ${essls_pid:-null},     "alive": $essls_alive,     "ready": $essls_ready,     "port_open": $p9200  },
+    "esstack":   { "pid": ${esstack_pid:-null},   "alive": $esstack_alive,   "ready": $esstack_ready,   "port_open": $p9201  },
+    "optimizer": { "pid": ${optimizer_pid:-null},  "alive": $optimizer_alive  },
+    "kbnsls":    { "pid": ${kbnsls_pid:-null},    "alive": $kbnsls_alive,    "ready": $kbnsls_ready,    "port_open": $p5601, "url": "http://localhost:5601" },
+    "kbnstack":  { "pid": ${kbnstack_pid:-null},  "alive": $kbnstack_alive,  "ready": $kbnstack_ready,  "port_open": $p5611, "url": "http://localhost:5611" }
+  }
+}
+EOF
+    return
+  fi
+
+  echo ""
+  echo "kbn-dev status"
+  echo "=========="
+  if [ "$main_alive" = true ]; then
+    echo "  Controller:   running (PID $main_pid, state: $state)"
+  else
+    echo "  Controller:   not running"
+  fi
+  echo ""
+
+  local fmt="  %-12s  %-8s  %-8s  %s\n"
+  printf "$fmt" "COMPONENT" "PROCESS" "READY" "PORT"
+  printf "$fmt" "---------" "-------" "-----" "----"
+  printf "$fmt" "essls"     "$([ "$essls_alive" = true ] && echo "up" || echo "down")"     "$([ "$essls_ready" = true ] && echo "yes" || echo "no")"     "9200 $([ "$p9200" = true ] && echo "open" || echo "closed")"
+  printf "$fmt" "esstack"   "$([ "$esstack_alive" = true ] && echo "up" || echo "down")"   "$([ "$esstack_ready" = true ] && echo "yes" || echo "no")"   "9201 $([ "$p9201" = true ] && echo "open" || echo "closed")"
+  printf "$fmt" "optimizer" "$([ "$optimizer_alive" = true ] && echo "up" || echo "down")"  "-"                                                            "-"
+  printf "$fmt" "kbnsls"    "$([ "$kbnsls_alive" = true ] && echo "up" || echo "down")"    "$([ "$kbnsls_ready" = true ] && echo "yes" || echo "no")"    "5601 $([ "$p5601" = true ] && echo "open" || echo "closed")"
+  printf "$fmt" "kbnstack"  "$([ "$kbnstack_alive" = true ] && echo "up" || echo "down")"  "$([ "$kbnstack_ready" = true ] && echo "yes" || echo "no")"  "5611 $([ "$p5611" = true ] && echo "open" || echo "closed")"
+  echo ""
+  echo "  Logs: $LOG_DIR"
+  echo ""
+}
+
+# --- logs -------------------------------------------------------------------
+cmd_logs() {
+  local comp="${1:-}"
+  shift || true
+
+  if [ -z "$comp" ]; then
+    echo "Usage: yarn kbn-dev-ctl logs <component> [--tail N] [--follow] [--grep PATTERN]"
+    echo "Components: essls, esstack, optimizer, kbnsls, kbnstack, main, all"
+    exit 1
+  fi
+
+  local tail_n=50 follow=false grep_pattern=""
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --tail)   tail_n="$2"; shift 2 ;;
+      --follow) follow=true; shift ;;
+      --grep)   grep_pattern="$2"; shift 2 ;;
+      *)        echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  local components
+  if [ "$comp" = "all" ]; then
+    components="essls esstack optimizer kbnsls kbnstack"
+  else
+    components="$comp"
+  fi
+
+  for c in $components; do
+    local logfile
+    logfile=$(component_log "$c")
+    if [ ! -f "$logfile" ]; then
+      echo "[$c] Log file not found: $logfile"
+      continue
+    fi
+
+    if [ "$comp" = "all" ]; then
+      echo ""
+      echo "=== $c ==="
+    fi
+
+    if [ "$follow" = true ]; then
+      if [ -n "$grep_pattern" ]; then
+        tail -f "$logfile" | grep --line-buffered "$grep_pattern"
+      else
+        tail -f "$logfile"
+      fi
+    else
+      local content
+      content=$(tail -n "$tail_n" "$logfile")
+      if [ -n "$grep_pattern" ]; then
+        echo "$content" | grep "$grep_pattern" || true
+      else
+        echo "$content"
+      fi
+    fi
+  done
+}
+
+# --- restart ----------------------------------------------------------------
+cmd_restart() {
+  local comp="${1:-}"
+  if [ "$comp" != "kbnsls" ] && [ "$comp" != "kbnstack" ]; then
+    echo "Usage: yarn kbn-dev-ctl restart <kbnsls|kbnstack>"
+    echo "  Only Kibana processes support restart (ES clusters and optimizer stay running)."
+    exit 1
+  fi
+
+  local port pidfile
+  if [ "$comp" = "kbnsls" ]; then
+    port=5601
+    pidfile="$LOG_DIR/kbnsls.pid"
+  else
+    port=5611
+    pidfile="$LOG_DIR/kbnstack.pid"
+  fi
+
+  echo "Restarting $comp..."
+
+  # Kill the Kibana process on its port
+  local kbn_port_pid
+  kbn_port_pid=$(lsof -ti "tcp:$port" 2>/dev/null)
+  if [ -n "$kbn_port_pid" ]; then
+    echo "  Killing process $kbn_port_pid on port $port"
+    kill "$kbn_port_pid" 2>/dev/null || true
+    sleep 2
+    kill -0 "$kbn_port_pid" 2>/dev/null && kill -9 "$kbn_port_pid" 2>/dev/null || true
+  fi
+
+  echo "  The monitor_process loop in kbn-dev will auto-restart $comp."
+  echo "  Watch the logs: tail -f $(component_log "$comp")"
+}
+
+# --- stop -------------------------------------------------------------------
+cmd_stop() {
+  local main_pid=""
+  [ -f "$LOG_DIR/kbn.pid" ] && main_pid=$(cat "$LOG_DIR/kbn.pid" 2>/dev/null)
+
+  if [ -z "$main_pid" ] || ! kill -0 "$main_pid" 2>/dev/null; then
+    echo "No running kbn-dev instance found."
+    return
+  fi
+
+  echo "Stopping kbn-dev (PID $main_pid)..."
+  kill "$main_pid" 2>/dev/null
+  echo "Sent SIGTERM. Cleanup will handle child processes."
+}
+
+# --- Main dispatch ----------------------------------------------------------
+case "${1:-status}" in
+  status)  shift 2>/dev/null || true; cmd_status "$@" ;;
+  logs)    shift; cmd_logs "$@" ;;
+  attach)  exec tmux attach -t kbn-logs ;;
+  restart) shift; cmd_restart "$@" ;;
+  stop)    cmd_stop ;;
+  -h|--help|help)
+    echo "Usage: yarn kbn-dev-ctl <command> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  status [--json]              Show component health"
+    echo "  logs <component> [options]   View component logs"
+    echo "  attach                       Attach to the tmux log viewer"
+    echo "  restart <kbnsls|kbnstack>    Restart a Kibana instance"
+    echo "  stop                         Stop the kbn-dev instance"
+    echo ""
+    echo "Components: essls, esstack, optimizer, kbnsls, kbnstack, main, all"
+    echo ""
+    echo "Log options:"
+    echo "  --tail N       Number of lines (default 50)"
+    echo "  --follow       Follow (tail -f)"
+    echo "  --grep PATTERN Filter lines"
+    ;;
+  *)
+    echo "Unknown command: $1" >&2
+    echo "Run 'yarn kbn-dev-ctl help' for usage." >&2
+    exit 1
+    ;;
+esac

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -247,12 +247,14 @@ cmd_restart() {
   fi
 
   echo ""
-  echo "  Starting kbn-dev..."
+  echo "  Starting kbn-dev in background..."
   if [ -f "scripts/kbn_dev.sh" ]; then
-    exec bash scripts/kbn_dev.sh --quiet
+    bash scripts/kbn_dev.sh --quiet &
   else
-    exec kbn --quiet
+    kbn --quiet &
   fi
+  echo "  PID: $!"
+  echo "  Use 'yarn kbn-dev-ctl status' to monitor."
 }
 
 # --- stop -------------------------------------------------------------------

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -19,6 +19,22 @@
 
 set -euo pipefail
 
+# --- Node / nvm setup -------------------------------------------------------
+# Agent shells (Claude Code, Cursor, CI) don't load nvm by default, so yarn
+# commands fail with "The engine node is incompatible". Source nvm here so
+# every subcommand sees the right node binary.
+if [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
+  export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+  # shellcheck disable=SC1091
+  . "$NVM_DIR/nvm.sh" --no-use
+  if [ -f ".nvmrc" ]; then
+    nvm use --silent 2>/dev/null || true
+  fi
+  if [ -n "${NVM_BIN:-}" ]; then
+    export PATH="$NVM_BIN:$PATH"
+  fi
+fi
+
 # --- Locate log directory ---------------------------------------------------
 find_log_dir() {
   local d="${KBN_LOG_DIR:-$HOME/.kbn/logs}"
@@ -61,7 +77,12 @@ check_ready() {
 }
 
 # --- status -----------------------------------------------------------------
+# Disable errexit/pipefail for the status function. A grep no-match (exit 1)
+# inside a pipeline with pipefail + set -e kills the script before any output,
+# causing false "not running" reports from skill dynamic injection fallbacks.
 cmd_status() {
+  set +eo pipefail
+
   local json_mode=false
   [ "${1:-}" = "--json" ] && json_mode=true
 
@@ -75,11 +96,11 @@ cmd_status() {
 
   local essls_pid="" esstack_pid="" optimizer_pid="" kbnsls_pid="" kbnstack_pid=""
   if [ -f "$STATUS_FILE" ]; then
-    essls_pid=$(grep -o '"essls".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
-    esstack_pid=$(grep -o '"esstack".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
-    optimizer_pid=$(grep -o '"optimizer".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
-    kbnsls_pid=$(grep -o '"kbnsls".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
-    kbnstack_pid=$(grep -o '"kbnstack".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g')
+    essls_pid=$(grep -o '"essls".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g') || true
+    esstack_pid=$(grep -o '"esstack".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g') || true
+    optimizer_pid=$(grep -o '"optimizer".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g') || true
+    kbnsls_pid=$(grep -o '"kbnsls".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g') || true
+    kbnstack_pid=$(grep -o '"kbnstack".*"pid": *"[^"]*"' "$STATUS_FILE" 2>/dev/null | grep -o '"pid": *"[^"]*"' | head -1 | sed 's/.*"pid": *"//;s/"//g') || true
   fi
 
   local essls_alive=false esstack_alive=false optimizer_alive=false

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -231,14 +231,19 @@ cmd_restart() {
 
   echo "Restarting $comp..."
 
-  # Kill the Kibana process on its port
+  # Kill the Kibana process listening on its port
   local kbn_port_pid
-  kbn_port_pid=$(lsof -ti "tcp:$port" 2>/dev/null)
+  kbn_port_pid=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -1)
   if [ -n "$kbn_port_pid" ]; then
-    echo "  Killing process $kbn_port_pid on port $port"
+    echo "  Killing PID $kbn_port_pid on port $port"
     kill "$kbn_port_pid" 2>/dev/null || true
     sleep 2
-    kill -0 "$kbn_port_pid" 2>/dev/null && kill -9 "$kbn_port_pid" 2>/dev/null || true
+    if kill -0 "$kbn_port_pid" 2>/dev/null; then
+      echo "  Force-killing PID $kbn_port_pid"
+      kill -9 "$kbn_port_pid" 2>/dev/null || true
+    fi
+  else
+    echo "  No process listening on port $port"
   fi
 
   echo "  The monitor_process loop in kbn-dev will auto-restart $comp."

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -247,14 +247,23 @@ cmd_restart() {
   fi
 
   echo ""
-  echo "  Starting kbn-dev in background..."
-  if [ -f "scripts/kbn_dev.sh" ]; then
-    bash scripts/kbn_dev.sh --quiet &
+  if [ -t 0 ]; then
+    echo "  Starting kbn-dev..."
+    if [ -f "scripts/kbn_dev.sh" ]; then
+      exec bash scripts/kbn_dev.sh
+    else
+      exec kbn
+    fi
   else
-    kbn --quiet &
+    echo "  Starting kbn-dev in background..."
+    if [ -f "scripts/kbn_dev.sh" ]; then
+      bash scripts/kbn_dev.sh --quiet &
+    else
+      kbn --quiet &
+    fi
+    echo "  PID: $!"
+    echo "  Use 'yarn kbn-dev-ctl status' to monitor."
   fi
-  echo "  PID: $!"
-  echo "  Use 'yarn kbn-dev-ctl status' to monitor."
 }
 
 # --- stop -------------------------------------------------------------------

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -246,7 +246,19 @@ cmd_restart() {
     echo "  No process listening on port $port"
   fi
 
-  echo "  The monitor_process loop in kbn-dev will auto-restart $comp."
+  # Verify the ES cluster backing this Kibana instance is reachable
+  local es_port
+  [ "$comp" = "kbnsls" ] && es_port=9200 || es_port=9201
+  local es_code
+  es_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$es_port" 2>/dev/null || echo "000")
+  if [ "$es_code" = "000" ]; then
+    echo ""
+    echo "  WARNING: ES on port $es_port is not responding."
+    echo "  Kibana will not start without ES. You may need a full restart:"
+    echo "    yarn kbn-dev-ctl stop && yarn kbn-dev"
+  else
+    echo "  The monitor_process loop in kbn-dev will auto-restart $comp."
+  fi
   echo "  Watch the logs: tail -f $(component_log "$comp")"
 }
 

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -103,10 +103,12 @@ cmd_status() {
   if [ "$esstack_alive" = true ] || [ "$p9201" = true ]; then
     check_ready "$LOG_DIR/esstack.log" "succ ES cluster is ready" && esstack_ready=true
   fi
-  if [ "$kbnsls_alive" = true ] || [ "$p5601" = true ]; then
+  # Kibana ready = log says available AND port is actually open.
+  # The log check alone is unreliable after restarts (stale messages).
+  if [ "$p5601" = true ]; then
     check_ready "$LOG_DIR/kbnsls.log" "\[INFO \]\[status\] Kibana is now available" && kbnsls_ready=true
   fi
-  if [ "$kbnstack_alive" = true ] || [ "$p5611" = true ]; then
+  if [ "$p5611" = true ]; then
     check_ready "$LOG_DIR/kbnstack.log" "\[INFO \]\[status\] Kibana is now available" && kbnstack_ready=true
   fi
 

--- a/scripts/kbn_dev_ctl.sh
+++ b/scripts/kbn_dev_ctl.sh
@@ -216,52 +216,43 @@ cmd_logs() {
 # --- restart ----------------------------------------------------------------
 cmd_restart() {
   local comp="${1:-}"
-  if [ "$comp" != "kbnsls" ] && [ "$comp" != "kbnstack" ]; then
-    echo "Usage: yarn kbn-dev-ctl restart <kbnsls|kbnstack>"
-    echo "  Only Kibana processes support restart (ES clusters and optimizer stay running)."
+  if [ "$comp" != "kbnsls" ] && [ "$comp" != "kbnstack" ] && [ "$comp" != "serverless" ] && [ "$comp" != "stateful" ] && [ "$comp" != "all" ]; then
+    echo "Usage: yarn kbn-dev-ctl restart <serverless|stateful|all>"
+    echo "  Restarts both ES and Kibana for the given mode."
+    echo "  Aliases: kbnsls = serverless, kbnstack = stateful"
     exit 1
   fi
 
-  local port pidfile
-  if [ "$comp" = "kbnsls" ]; then
-    port=5601
-    pidfile="$LOG_DIR/kbnsls.pid"
-  else
-    port=5611
-    pidfile="$LOG_DIR/kbnstack.pid"
-  fi
+  # Normalize aliases
+  [ "$comp" = "kbnsls" ] && comp="serverless"
+  [ "$comp" = "kbnstack" ] && comp="stateful"
 
-  echo "Restarting $comp..."
+  echo "Restarting $comp — this does a full stop + start."
+  echo ""
 
-  # Kill the Kibana process listening on its port
-  local kbn_port_pid
-  kbn_port_pid=$(lsof -nP -iTCP:"$port" -sTCP:LISTEN -t 2>/dev/null | head -1)
-  if [ -n "$kbn_port_pid" ]; then
-    echo "  Killing PID $kbn_port_pid on port $port"
-    kill "$kbn_port_pid" 2>/dev/null || true
-    sleep 2
-    if kill -0 "$kbn_port_pid" 2>/dev/null; then
-      echo "  Force-killing PID $kbn_port_pid"
-      kill -9 "$kbn_port_pid" 2>/dev/null || true
-    fi
-  else
-    echo "  No process listening on port $port"
-  fi
+  cmd_stop
+  sleep 3
 
-  # Verify the ES cluster backing this Kibana instance is reachable
-  local es_port
-  [ "$comp" = "kbnsls" ] && es_port=9200 || es_port=9201
-  local es_code
-  es_code=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:$es_port" 2>/dev/null || echo "000")
-  if [ "$es_code" = "000" ]; then
+  if ! [ -f "package.json" ] || ! grep -q '"name": "kibana"' package.json 2>/dev/null; then
     echo ""
-    echo "  ERROR: ES on port $es_port is not responding."
-    echo "  Kibana cannot start without ES. A full restart is needed:"
-    echo "    yarn kbn-dev-ctl stop && yarn kbn-dev"
-    exit 1
+    echo "  Stopped. To start again, run from the kibana repo root:"
+    echo "    yarn kbn-dev"
+    return
   fi
-  echo "  The monitor_process loop will auto-restart $comp."
-  echo "  Watch the logs: tail -f $(component_log "$comp")"
+
+  if ! command -v kbn >/dev/null 2>&1 && ! [ -f "scripts/kbn_dev.sh" ]; then
+    echo ""
+    echo "  Stopped. To start again: yarn kbn-dev"
+    return
+  fi
+
+  echo ""
+  echo "  Starting kbn-dev..."
+  if [ -f "scripts/kbn_dev.sh" ]; then
+    exec bash scripts/kbn_dev.sh --quiet
+  else
+    exec kbn --quiet
+  fi
 }
 
 # --- stop -------------------------------------------------------------------
@@ -293,7 +284,7 @@ case "${1:-status}" in
     echo "  status [--json]              Show component health"
     echo "  logs <component> [options]   View component logs"
     echo "  attach                       Attach to the tmux log viewer"
-    echo "  restart <kbnsls|kbnstack>    Restart a Kibana instance"
+    echo "  restart <serverless|stateful|all>  Full restart (ES + Kibana)"
     echo "  stop                         Stop the kbn-dev instance"
     echo ""
     echo "Components: essls, esstack, optimizer, kbnsls, kbnstack, main, all"

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
@@ -346,6 +346,24 @@ export const UIAM_CONTAINERS = UIAM_BASE_CONTAINERS;
  * Run a single UIAM-related container.
  */
 export async function runUiamContainer(log: ToolingLog, container: UiamContainer) {
+  // If the container is already running and healthy, reuse it
+  try {
+    const { stdout: existingStatus } = await execa('docker', [
+      'inspect',
+      '-f',
+      '{{.State.Health.Status}}',
+      container.name,
+    ]);
+    if (existingStatus.trim() === 'healthy') {
+      log.info(
+        chalk.bold(`"${container.name}" container is already running and healthy — reusing.`)
+      );
+      return container.name;
+    }
+  } catch {
+    // Container doesn't exist — proceed with creation
+  }
+
   const dockerCommand = SHARED_DOCKER_PARAMS.concat(
     container.params,
     ['--name', container.name],

--- a/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
+++ b/src/platform/packages/shared/kbn-es/src/utils/docker_uiam.ts
@@ -346,24 +346,6 @@ export const UIAM_CONTAINERS = UIAM_BASE_CONTAINERS;
  * Run a single UIAM-related container.
  */
 export async function runUiamContainer(log: ToolingLog, container: UiamContainer) {
-  // If the container is already running and healthy, reuse it
-  try {
-    const { stdout: existingStatus } = await execa('docker', [
-      'inspect',
-      '-f',
-      '{{.State.Health.Status}}',
-      container.name,
-    ]);
-    if (existingStatus.trim() === 'healthy') {
-      log.info(
-        chalk.bold(`"${container.name}" container is already running and healthy — reusing.`)
-      );
-      return container.name;
-    }
-  } catch {
-    // Container doesn't exist — proceed with creation
-  }
-
   const dockerCommand = SHARED_DOCKER_PARAMS.concat(
     container.params,
     ['--name', container.name],


### PR DESCRIPTION
## Summary

Adds `yarn kbn-dev` and `yarn kbn-dev-ctl` as in-repo scripts for spinning up the complete dual-mode Kibana dev environment (serverless on :5601, stateful on :5611) in a single command. This replaces manually running `yarn es` + `yarn start` for each mode.

### Files added/modified

**New scripts:**
- `scripts/kbn_dev.sh` — orchestrator that boots ES (serverless + stateful), optimizer, and both Kibana instances in parallel with auto-retry, Chrome profile management, and tmux log viewer
- `scripts/kbn_dev_ctl.sh` — control plane for status, logs, restart, stop, and tmux attach

**New skills (for Claude/agent integration):**
- `.agents/skills/kbn-dev/SKILL.md` — full agent skill for starting, monitoring, and recovering the dev environment
- `.agents/skills/kbn-dev/failure-modes.md` — failure diagnosis reference
- `.agents/skills/kbn-dev-status/SKILL.md` — quick status check skill

**Modified:**
- `package.json` — added `kbn-dev` and `kbn-dev-ctl` yarn scripts
- `AGENTS.md` — added setup line referencing `yarn kbn-dev`

## Test plan

- [ ] Run `yarn kbn-dev --quiet` from the kibana repo root and verify both Kibana instances come up
- [ ] Run `yarn kbn-dev-ctl status --json` and verify JSON output
- [ ] Run `yarn kbn-dev-ctl logs essls --tail 10` and verify log output
- [ ] Run `yarn kbn-dev-ctl stop` and verify clean shutdown
- [ ] Verify `bash -n scripts/kbn_dev.sh` and `bash -n scripts/kbn_dev_ctl.sh` pass (syntax check)


Made with [Cursor](https://cursor.com)